### PR TITLE
Specific versions in rosinstall

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: cmake_common_scripts
     uri: https://github.com/ros-industrial/cmake_common_scripts.git
-    version: master
+    version: 0.2.5
 - git:
     local-name: tesseract
     uri: https://github.com/ros-industrial-consortium/tesseract.git
@@ -13,12 +13,12 @@
 - git:
     local-name: descartes_light
     uri: https://github.com/swri-robotics/descartes_light.git
-    version: master
+    version: 0.2.0
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
-    version: master
+    version: 0.3.1
 - git:
     local-name: ifopt
     uri: https://github.com/ethz-adrl/ifopt.git
-    version: master
+    version: 4732b0c84bfbc4f8e14b3befc947ef0407dba95a


### PR DESCRIPTION
Per the title, this PR changes the rosinstall to use specific versions of external dependencies rather than named branches