### PR TITLE
Graph Taskflow Generator Revision

### DIFF
--- a/.github/workflows/focal_build.yml
+++ b/.github/workflows/focal_build.yml
@@ -24,7 +24,7 @@ jobs:
       CCACHE_DIR: "/home/runner/work/tesseract_planning/tesseract_planning/Focal-Build/.ccache"
       PARALLEL_TESTS: false
       PARALLEL_BUILDS: false
-      BEFORE_RUN_TARGET_TEST_EMBED: "source /root/target_ws/install/setup.bash"
+      BEFORE_RUN_TARGET_TEST_EMBED: "ici_with_unset_variables source /root/target_ws/install/setup.bash"
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
     steps:

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
@@ -73,8 +73,9 @@ public:
    * as the output of a non-conditional tf::Task is void. If source is a conditional task, the order
    * of the destinations should correspond to the integer output of the conditional tf::Task **plus one**.
    * The connection at index zero is reserved for the error callback. As an example,if the output of the
-   * conditional tf::Task is 2, the taskflow would transition to the node identified by the ID at index 1 in the destinations input
-   * A leaf node is always connected to the done callback. When the leaf node is a conditional node, the done callback is the connection at index 1
+   * conditional tf::Task is 2, the taskflow would transition to the node identified by the ID at index 1 in the
+   * destinations input A leaf node is always connected to the done callback. When the leaf node is a conditional node,
+   * the done callback is the connection at index 1
    *
    * Remember: when source is a conditional node, the connection at index 0 is always to the error callback
    *

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
@@ -69,16 +69,12 @@ public:
 
   /**
    * @brief Adds directed edges from a source node to desintation nodes in the taskflow graph
-   * @details If source is a non-conditional task, it is only relevant to provide one destination
-   * as the output of a non-conditional tf::Task is void. If source is a conditional task, the order
-   * of the destinations should correspond to the integer output of the conditional tf::Task **plus one**.
-   * The connection at index zero is reserved for the error callback. As an example,if the output of the
-   * conditional tf::Task is 2, the taskflow would transition to the node identified by the ID at index 1 in the
-   * destinations input A leaf node is always connected to the done callback. When the leaf node is a conditional node,
-   * the done callback is the connection at index 1
-   *
-   * Remember: when source is a conditional node, the connection at index 0 is always to the error callback
-   *
+   * @details If source is a non-conditional task, it is only relevant to provide one destination as the output of a
+   * non-conditional tf::Task is void. If source is a conditional task, the order of the destinations should correspond
+   * to the integer output of the conditional tf::Task. For example,if the output of the conditional tf::Task is 0, the
+   * taskflow would transition to the node identified by the ID at index 0 in the destinations input. A leaf node (i.e.
+   * node without defined edges) is always connected to the done callback. If the leaf node is a conditional node, it is
+   * connected to the error task at index 0 and the done task at index 1
    * @param from The ID of the source node of the edge
    * @param dest A list of IDs of the destination nodes of the edges.
    */

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
@@ -84,7 +84,7 @@ private:
   /** @brief Helper struct for holding relevant information about the nodes */
   struct Node
   {
-    Node(TaskGenerator::UPtr process_, const bool is_conditional_);
+    Node(TaskGenerator::UPtr process_, bool is_conditional_);
 
     TaskGenerator::UPtr process;
     const bool is_conditional;

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/graph_taskflow.h
@@ -40,47 +40,13 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 /**
- * @brief This class generates taskflow graph. It allows you to connect different channels from the source to the
- *        destination process
+ * @brief This class facilitates the composition of an arbitrary taskflow graph.
+ * Tasks are nodes in the graph connected to each other in a configurable order by directed edges
  */
 class GraphTaskflow : public TaskflowGenerator
 {
 public:
   using UPtr = std::unique_ptr<GraphTaskflow>;
-
-  enum class NodeType : int
-  {
-    TASK = 0,
-    CONDITIONAL = 1
-  };
-
-  enum class SourceChannel : int
-  {
-    NONE = 0,
-    ON_SUCCESS = 1,
-    ON_FAILURE = 2
-  };
-
-  enum class DestinationChannel : int
-  {
-    PROCESS_NODE = 0,
-    DONE_CALLBACK = 1,
-    ERROR_CALLBACK = 2
-  };
-
-  struct Edge
-  {
-    SourceChannel src_channel;
-    int dest{ -1 };
-    DestinationChannel dest_channel;
-  };
-
-  struct Node
-  {
-    TaskGenerator::UPtr process;
-    NodeType process_type;
-    std::vector<Edge> edges;
-  };
 
   GraphTaskflow(std::string name = "GraphTaskflow");
   ~GraphTaskflow() override = default;
@@ -96,23 +62,39 @@ public:
   /**
    * @brief Add a node to the taskflow graph along with setting the process type.
    * @param process The process generator assigned to the node
-   * @param process_type The process type assigned to the node
+   * @param is_conditional Flag indicating if this process is conditional
    * @return The node ID which should be used with adding edges
    */
-  int addNode(TaskGenerator::UPtr process, NodeType process_type);
+  int addNode(TaskGenerator::UPtr process, bool is_conditional = false);
 
   /**
-   * @brief Add an edge to the taskflow graph
-   * @param src The source node ID
-   * @param src_channel The source channel (ON_SUCCESS, ON_FAILURE)
-   * @param dest The destination node ID (This is only required for destination channels PROCESS_NODE) othewise pass a
-   * -1
-   * @param dest_channel The destination channel to connect with the source channel (PROCESS_NODE, DONE_CALLBACK,
-   * ERROR_CALLBACK).
+   * @brief Adds directed edges from a source node to desintation nodes in the taskflow graph
+   * @details If source is a non-conditional task, it is only relevant to provide one destination
+   * as the output of a non-conditional tf::Task is void. If source is a conditional task, the order
+   * of the destinations should correspond to the integer output of the conditional tf::Task **plus one**.
+   * The connection at index zero is reserved for the error callback. As an example,if the output of the
+   * conditional tf::Task is 2, the taskflow would transition to the node identified by the ID at index 1 in the destinations input
+   * A leaf node is always connected to the done callback. When the leaf node is a conditional node, the done callback is the connection at index 1
+   *
+   * Remember: when source is a conditional node, the connection at index 0 is always to the error callback
+   *
+   * @param from The ID of the source node of the edge
+   * @param dest A list of IDs of the destination nodes of the edges.
    */
-  void addEdge(int src, SourceChannel src_channel, int dest, DestinationChannel dest_channel);
+  void addEdges(int source, std::vector<int> destinations);
 
 private:
+  /** @brief Helper struct for holding relevant information about the nodes */
+  struct Node
+  {
+    Node(TaskGenerator::UPtr process_, const bool is_conditional_);
+
+    TaskGenerator::UPtr process;
+    const bool is_conditional;
+    /** @brief IDs of nodes (i.e. tasks) that should run after this node */
+    std::vector<int> edges;
+  };
+
   std::vector<Node> nodes_;
   std::string name_;
 };

--- a/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
@@ -37,7 +37,7 @@ namespace tesseract_planning
 {
 GraphTaskflow::GraphTaskflow(std::string name) : name_(std::move(name)) {}
 
-GraphTaskflow::Node::Node(TaskGenerator::UPtr process_, const bool is_conditional_)
+GraphTaskflow::Node::Node(TaskGenerator::UPtr process_, bool is_conditional_)
   : process(std::move(process_)), is_conditional(is_conditional_)
 {
 }

--- a/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
@@ -37,6 +37,12 @@ namespace tesseract_planning
 {
 GraphTaskflow::GraphTaskflow(std::string name) : name_(std::move(name)) {}
 
+GraphTaskflow::Node::Node(TaskGenerator::UPtr process_, const bool is_conditional_)
+  : process(std::move(process_))
+  , is_conditional(is_conditional_)
+{
+}
+
 const std::string& GraphTaskflow::getName() const { return name_; }
 
 TaskflowContainer GraphTaskflow::generateTaskflow(TaskInput input, TaskflowVoidFn done_cb, TaskflowVoidFn error_cb)
@@ -47,159 +53,68 @@ TaskflowContainer GraphTaskflow::generateTaskflow(TaskInput input, TaskflowVoidF
 
   // Add "Error" task
   auto error_fn = [=]() { failureTask(input, name_, "", error_cb); };
-  tf::Task error_task = container.taskflow->emplace(error_fn).name("Error Callback");
-  container.outputs.push_back(error_task);
+  container.outputs.push_back(container.taskflow->emplace(error_fn).name("Error Callback"));
 
   // Add "Done" task
   auto done_fn = [=]() { successTask(input, name_, "", done_cb); };
-  tf::Task done_task = container.taskflow->emplace(done_fn).name("Done Callback");
-  container.outputs.push_back(done_task);
+  container.outputs.push_back(container.taskflow->emplace(done_fn).name("Done Callback"));
+
+  // Grab references to the error and done tasks for use later
+  const tf::Task& error_task = container.outputs.at(0);
+  const tf::Task& done_task = container.outputs.at(1);
 
   // Generate process tasks for each node using its process generator
   std::vector<tf::Task> tasks;
   tasks.reserve(nodes_.size());
-  for (auto& node : nodes_)
+  for (Node& node : nodes_)
   {
-    switch (node.process_type)
-    {
-      case NodeType::TASK:
-      {
-        tasks.push_back(node.process->generateTask(input, *(container.taskflow)));
-        break;
-      }
-      case NodeType::CONDITIONAL:
-      {
-        tasks.push_back(node.process->generateConditionalTask(input, *(container.taskflow)));
-        break;
-      }
-    }
+    if (node.is_conditional)
+      tasks.push_back(node.process->generateConditionalTask(input, *(container.taskflow)));
+    else
+      tasks.push_back(node.process->generateTask(input, *(container.taskflow)));
   }
 
-  std::size_t src_idx = 0;
-  for (auto& node : nodes_)
+  for (std::size_t i = 0; i < nodes_.size(); ++i)
   {
-    std::size_t src = src_idx;
-    if (node.process_type == NodeType::TASK)
+    // Ensure the current task precedes the tasks that it is connected to
+    const Node& node = nodes_[i];
+
+    // Make sure the 0th connection of a conditional task goes to the error task
+    if (node.is_conditional)
     {
-      assert(node.edges.size() == 1);
-      if (node.edges[0].dest_channel == DestinationChannel::PROCESS_NODE)
-        tasks[src].precede(tasks[static_cast<std::size_t>(node.edges[0].dest)]);
-      else if (node.edges[0].dest_channel == DestinationChannel::DONE_CALLBACK)
-        tasks[src].precede(container.outputs[1]);
-      else if (node.edges[0].dest_channel == DestinationChannel::ERROR_CALLBACK)
-        tasks[src].precede(container.outputs[0]);
+      tasks.at(i).precede(error_task);
     }
-    else if (node.process_type == NodeType::CONDITIONAL)
+
+    // Add the other edges
+    for (int idx : node.edges)
     {
-      assert(node.edges.size() == 2);
-      if (node.edges[0].dest_channel == DestinationChannel::PROCESS_NODE &&
-          node.edges[1].dest_channel == DestinationChannel::PROCESS_NODE)
-      {
-        if (node.edges[0].src_channel == SourceChannel::ON_SUCCESS &&
-            node.edges[1].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(tasks[static_cast<std::size_t>(node.edges[1].dest)],
-                             tasks[static_cast<std::size_t>(node.edges[0].dest)]);
-        else if (node.edges[1].src_channel == SourceChannel::ON_SUCCESS &&
-                 node.edges[0].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(tasks[static_cast<std::size_t>(node.edges[0].dest)],
-                             tasks[static_cast<std::size_t>(node.edges[1].dest)]);
-      }
-      else if (node.edges[0].dest_channel == DestinationChannel::PROCESS_NODE &&
-               node.edges[1].dest_channel == DestinationChannel::DONE_CALLBACK)
-      {
-        if (node.edges[0].src_channel == SourceChannel::ON_SUCCESS &&
-            node.edges[1].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[1], tasks[static_cast<std::size_t>(node.edges[0].dest)]);
-        else if (node.edges[1].src_channel == SourceChannel::ON_SUCCESS &&
-                 node.edges[0].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(tasks[static_cast<std::size_t>(node.edges[0].dest)], container.outputs[1]);
-      }
-      else if (node.edges[0].dest_channel == DestinationChannel::PROCESS_NODE &&
-               node.edges[1].dest_channel == DestinationChannel::ERROR_CALLBACK)
-      {
-        if (node.edges[0].src_channel == SourceChannel::ON_SUCCESS &&
-            node.edges[1].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[0], tasks[static_cast<std::size_t>(node.edges[0].dest)]);
-        else if (node.edges[1].src_channel == SourceChannel::ON_SUCCESS &&
-                 node.edges[0].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(tasks[static_cast<std::size_t>(node.edges[0].dest)], container.outputs[0]);
-      }
-      else if (node.edges[0].dest_channel == DestinationChannel::DONE_CALLBACK &&
-               node.edges[1].dest_channel == DestinationChannel::PROCESS_NODE)
-      {
-        if (node.edges[0].src_channel == SourceChannel::ON_SUCCESS &&
-            node.edges[1].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(tasks[static_cast<std::size_t>(node.edges[1].dest)], container.outputs[1]);
-        else if (node.edges[1].src_channel == SourceChannel::ON_SUCCESS &&
-                 node.edges[0].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[1], tasks[static_cast<std::size_t>(node.edges[1].dest)]);
-      }
-      else if (node.edges[0].dest_channel == DestinationChannel::ERROR_CALLBACK &&
-               node.edges[1].dest_channel == DestinationChannel::PROCESS_NODE)
-      {
-        if (node.edges[0].src_channel == SourceChannel::ON_SUCCESS &&
-            node.edges[1].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(tasks[static_cast<std::size_t>(node.edges[1].dest)], container.outputs[0]);
-        else if (node.edges[1].src_channel == SourceChannel::ON_SUCCESS &&
-                 node.edges[0].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[0], tasks[static_cast<std::size_t>(node.edges[1].dest)]);
-      }
-      else if (node.edges[0].dest_channel == DestinationChannel::DONE_CALLBACK &&
-               node.edges[1].dest_channel == DestinationChannel::ERROR_CALLBACK)
-      {
-        if (node.edges[0].src_channel == SourceChannel::ON_SUCCESS &&
-            node.edges[1].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[0], container.outputs[1]);
-        else if (node.edges[1].src_channel == SourceChannel::ON_SUCCESS &&
-                 node.edges[0].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[1], container.outputs[0]);
-      }
-      else if (node.edges[0].dest_channel == DestinationChannel::ERROR_CALLBACK &&
-               node.edges[1].dest_channel == DestinationChannel::DONE_CALLBACK)
-      {
-        if (node.edges[0].src_channel == SourceChannel::ON_SUCCESS &&
-            node.edges[1].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[1], container.outputs[0]);
-        else if (node.edges[1].src_channel == SourceChannel::ON_SUCCESS &&
-                 node.edges[0].src_channel == SourceChannel::ON_FAILURE)
-          tasks[src].precede(container.outputs[0], container.outputs[1]);
-      }
-      else
-      {
-        throw std::runtime_error("Invalid Edges for process index: " + std::to_string(src_idx));
-      }
+      tasks.at(i).precede(tasks.at(static_cast<std::size_t>(idx)));
     }
-    ++src_idx;
+
+    // If no edges exist for the current node, then make sure this node precedes the done task
+    if (node.edges.empty())
+    {
+      tasks.at(i).precede(done_task);
+    }
   }
 
   // Assumes the first node added is the input node
-  container.input = tasks[0];
+  container.input = tasks.front();
   return container;
 }
 
-int GraphTaskflow::addNode(TaskGenerator::UPtr process, NodeType process_type)
+int GraphTaskflow::addNode(TaskGenerator::UPtr process, bool is_conditional)
 {
-  Node pn;
-  pn.process = std::move(process);
-  pn.process_type = process_type;
-
-  nodes_.push_back(std::move(pn));
-
-  return static_cast<int>(nodes_.size()) - 1;
+  nodes_.emplace_back(Node(std::move(process), is_conditional));
+  return static_cast<int>(nodes_.size() - 1);
 }
 
-void GraphTaskflow::addEdge(int src, SourceChannel src_channel, int dest, DestinationChannel dest_channel)
+void GraphTaskflow::addEdges(int source, std::vector<int> destinations)
 {
-  Edge e;
-  e.src_channel = src_channel;
-  e.dest = dest;
-  e.dest_channel = dest_channel;
-
-  Node& n = nodes_[static_cast<std::size_t>(src)];
-  n.edges.push_back(e);
-  if (n.edges.size() > 2)
-  {
-    CONSOLE_BRIDGE_logWarn("Currently a node should not have more than two edges!");
-  }
+  Node& node = nodes_.at(static_cast<std::size_t>(source));
+  if (destinations.size() > 1 && node.is_conditional)
+    node.edges.insert(node.edges.end(), destinations.begin(), destinations.end());
+  else
+    throw std::runtime_error("Multiple edges can only be added to conditional nodes");
 }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
@@ -38,8 +38,7 @@ namespace tesseract_planning
 GraphTaskflow::GraphTaskflow(std::string name) : name_(std::move(name)) {}
 
 GraphTaskflow::Node::Node(TaskGenerator::UPtr process_, const bool is_conditional_)
-  : process(std::move(process_))
-  , is_conditional(is_conditional_)
+  : process(std::move(process_)), is_conditional(is_conditional_)
 {
 }
 

--- a/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/graph_taskflow.cpp
@@ -77,22 +77,19 @@ TaskflowContainer GraphTaskflow::generateTaskflow(TaskInput input, TaskflowVoidF
   {
     // Ensure the current task precedes the tasks that it is connected to
     const Node& node = nodes_[i];
-
-    // Make sure the 0th connection of a conditional task goes to the error task
-    if (node.is_conditional)
-    {
-      tasks.at(i).precede(error_task);
-    }
-
-    // Add the other edges
     for (int idx : node.edges)
     {
       tasks.at(i).precede(tasks.at(static_cast<std::size_t>(idx)));
     }
 
-    // If no edges exist for the current node, then make sure this node precedes the done task
+    // If no edges exist for the current node, make sure it precedes the done task (and error task if conditional)
     if (node.edges.empty())
     {
+      // Make sure the 0th connection of a conditional task goes to the error task
+      if (node.is_conditional)
+      {
+        tasks.at(i).precede(error_task);
+      }
       tasks.at(i).precede(done_task);
     }
   }

--- a/tesseract_process_managers/test/CMakeLists.txt
+++ b/tesseract_process_managers/test/CMakeLists.txt
@@ -54,3 +54,13 @@ target_cxx_version(${PROJECT_NAME}_fix_state_collision_task_generator_unit PRIVA
 target_code_coverage(${PROJECT_NAME}_fix_state_collision_task_generator_unit ALL EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 add_gtest_discover_tests(${PROJECT_NAME}_fix_state_collision_task_generator_unit)
 add_dependencies(run_tests ${PROJECT_NAME}_fix_state_collision_task_generator_unit)
+
+add_executable(${PROJECT_NAME}_graph_taskflow_unit graph_taskflow_unit.cpp)
+target_link_libraries(${PROJECT_NAME}_graph_taskflow_unit PUBLIC ${PROJECT_NAME} GTest::GTest GTest::Main)
+target_include_directories(${PROJECT_NAME}_graph_taskflow_unit PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
+target_cxx_version(${PROJECT_NAME}_graph_taskflow_unit PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_graph_taskflow_unit ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_code_coverage(${PROJECT_NAME}_graph_taskflow_unit ALL EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+add_gtest_discover_tests(${PROJECT_NAME}_graph_taskflow_unit)
+add_dependencies(run_tests ${PROJECT_NAME}_graph_taskflow_unit)

--- a/tesseract_process_managers/test/graph_taskflow_unit.cpp
+++ b/tesseract_process_managers/test/graph_taskflow_unit.cpp
@@ -1,0 +1,87 @@
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_process_managers/taskflow_generators/graph_taskflow.h>
+#include <tesseract_common/utils.h>
+
+using namespace tesseract_planning;
+
+class TestGenerator : public TaskGenerator
+{
+public:
+  TestGenerator(std::string name, int conditional_ret_val) : TaskGenerator(name), conditional_ret_val_(conditional_ret_val) {}
+
+  virtual void process(TaskInput, std::size_t) const override
+  {
+    std::cout << "Task " << name_ << std::endl;
+  }
+
+  virtual int conditionalProcess(TaskInput, std::size_t) const override
+  {
+    std::cout << "Task " << name_ << std::endl;
+    return conditional_ret_val_;
+  }
+
+private:
+  int conditional_ret_val_;
+};
+
+class TestObserver : public tf::ObserverInterface
+{
+public:
+  virtual void set_up(size_t) {}
+
+  virtual void on_entry(size_t, tf::TaskView) {}
+
+  virtual void on_exit(size_t, tf::TaskView task_view) { executed_tasks.push_back(task_view.name()); }
+
+  std::vector<std::string> executed_tasks;
+};
+
+TEST(GraphTaskflowGenerator, CreateAndRun)
+{
+  GraphTaskflow graph;
+  int A = graph.addNode(std::make_unique<TestGenerator>("A", 1), true);
+  int A1 = graph.addNode(std::make_unique<TestGenerator>("A1", 3), true);
+  int A2 = graph.addNode(std::make_unique<TestGenerator>("A2", -1), false);
+  int A3 = graph.addNode(std::make_unique<TestGenerator>("A3", -1), false);
+  int A11 = graph.addNode(std::make_unique<TestGenerator>("A11", -1), false);
+  int A12 = graph.addNode(std::make_unique<TestGenerator>("A12", -1), false);
+  int A13 = graph.addNode(std::make_unique<TestGenerator>("A13", 1), true);
+
+  ASSERT_NO_THROW(graph.addEdges(A, { A1, A2, A3 }));
+  ASSERT_NO_THROW(graph.addEdges(A1, { A11, A12, A13 }));
+
+  // Adding more than one edge to non-conditional nodes is not allowed
+  ASSERT_THROW(graph.addEdges(A2, { A11, A12, A13 }), std::runtime_error);
+  ASSERT_THROW(graph.addEdges(A3, { A11, A12, A13 }), std::runtime_error);
+
+  TaskInput input(nullptr, nullptr, {}, nullptr, false, {});
+
+  TaskflowVoidFn done_fn = []() { std::cout << "Done" << std::endl; };
+  TaskflowVoidFn error_fn = []() { std::cout << "Error" << std::endl; };
+  TaskflowContainer container;
+  ASSERT_NO_THROW(container = graph.generateTaskflow(input, done_fn, error_fn));
+
+  // Save the graph visualization
+  std::ofstream out_data;
+  out_data.open(tesseract_common::getTempPath() + "graph_taskflow-" + tesseract_common::getTimestampString() + ".dot");
+  container.taskflow->dump(out_data);
+  out_data.close();
+
+  // Run the taskflow with a custom observer that will record the states that get entered
+  tf::Executor executor(1);
+  auto obs = executor.make_observer<TestObserver>();
+  executor.run(*container.taskflow).wait();
+
+  std::vector<std::string> expected_executed_tasks = { "A", "A1", "A13", "Done Callback" };
+  ASSERT_EQ(expected_executed_tasks, obs->executed_tasks);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_process_managers/test/graph_taskflow_unit.cpp
+++ b/tesseract_process_managers/test/graph_taskflow_unit.cpp
@@ -43,20 +43,20 @@ public:
 TEST(GraphTaskflowGenerator, CreateAndRun)
 {
   GraphTaskflow graph;
-  int A = graph.addNode(std::make_unique<TestGenerator>("A", 1), true);
-  int A1 = graph.addNode(std::make_unique<TestGenerator>("A1", 3), true);
+  int A = graph.addNode(std::make_unique<TestGenerator>("A", 0), true);
+  int A0 = graph.addNode(std::make_unique<TestGenerator>("A0", 2), true);
+  int A1 = graph.addNode(std::make_unique<TestGenerator>("A1", -1), false);
   int A2 = graph.addNode(std::make_unique<TestGenerator>("A2", -1), false);
-  int A3 = graph.addNode(std::make_unique<TestGenerator>("A3", -1), false);
-  int A11 = graph.addNode(std::make_unique<TestGenerator>("A11", -1), false);
-  int A12 = graph.addNode(std::make_unique<TestGenerator>("A12", -1), false);
-  int A13 = graph.addNode(std::make_unique<TestGenerator>("A13", 1), true);
+  int A00 = graph.addNode(std::make_unique<TestGenerator>("A00", -1), false);
+  int A01 = graph.addNode(std::make_unique<TestGenerator>("A01", -1), false);
+  int A02 = graph.addNode(std::make_unique<TestGenerator>("A02", 1), true);
 
-  ASSERT_NO_THROW(graph.addEdges(A, { A1, A2, A3 }));
-  ASSERT_NO_THROW(graph.addEdges(A1, { A11, A12, A13 }));
+  ASSERT_NO_THROW(graph.addEdges(A, { A0, A1, A2 }));
+  ASSERT_NO_THROW(graph.addEdges(A0, { A00, A01, A02 }));
 
   // Adding more than one edge to non-conditional nodes is not allowed
-  ASSERT_THROW(graph.addEdges(A2, { A11, A12, A13 }), std::runtime_error);
-  ASSERT_THROW(graph.addEdges(A3, { A11, A12, A13 }), std::runtime_error);
+  ASSERT_THROW(graph.addEdges(A1, { A00, A01, A02 }), std::runtime_error);
+  ASSERT_THROW(graph.addEdges(A2, { A00, A01, A02 }), std::runtime_error);
 
   TaskInput input(nullptr, nullptr, {}, nullptr, false, {});
 
@@ -76,7 +76,7 @@ TEST(GraphTaskflowGenerator, CreateAndRun)
   auto obs = executor.make_observer<TestObserver>();
   executor.run(*container.taskflow).wait();
 
-  std::vector<std::string> expected_executed_tasks = { "A", "A1", "A13", "Done Callback" };
+  std::vector<std::string> expected_executed_tasks = { "A", "A0", "A02", "Done Callback" };
   ASSERT_EQ(expected_executed_tasks, obs->executed_tasks);
 }
 

--- a/tesseract_process_managers/test/graph_taskflow_unit.cpp
+++ b/tesseract_process_managers/test/graph_taskflow_unit.cpp
@@ -11,12 +11,12 @@ using namespace tesseract_planning;
 class TestGenerator : public TaskGenerator
 {
 public:
-  TestGenerator(std::string name, int conditional_ret_val) : TaskGenerator(name), conditional_ret_val_(conditional_ret_val) {}
-
-  virtual void process(TaskInput, std::size_t) const override
+  TestGenerator(std::string name, int conditional_ret_val)
+    : TaskGenerator(name), conditional_ret_val_(conditional_ret_val)
   {
-    std::cout << "Task " << name_ << std::endl;
   }
+
+  virtual void process(TaskInput, std::size_t) const override { std::cout << "Task " << name_ << std::endl; }
 
   virtual int conditionalProcess(TaskInput, std::size_t) const override
   {


### PR DESCRIPTION
This PR revises the graph Taskflow generator class to be easier to use.

## Assumptions

- End conditions
  - The required error task is only applicable to conditional nodes. I assign the error task as the connection at index 0 to all conditional tasks
  - The done callback is applicable to both conditional and non-conditional nodes.
    - If a conditional node has any edges, I do not connect that node to the done callback
    - If a conditional node is a leaf node (i.e. has no defined edges), the connection at index 0 is to the error task (as mentioned above) and the connection at index 1 is to the done task
    - If a non-conditional node is a leaf node, it's only connection is to the done callback
- No graph checking is implemented for loops and "island" states. I think we should allow users the freedom to define their graphs in whatever way possible. It's easy enough to dump the taskflow to a file and understand if the graph looks correct

All of these assumptions should be documented in the header file

## Test case

Below is the graph generated by the unit test using the revised graph Taskflow generator showing the assumptions detailed above

![image](https://user-images.githubusercontent.com/18411310/105057945-57f24e80-5a3b-11eb-8543-82de23a2f1e3.png)
