### PR TITLE
Remove tcmalloc as a library dependency

### DIFF
--- a/tesseract_process_managers/CMakeLists.txt
+++ b/tesseract_process_managers/CMakeLists.txt
@@ -19,10 +19,6 @@ find_package(tesseract_command_language REQUIRED)
 find_package(tesseract_motion_planners REQUIRED)
 find_package(tesseract_time_parameterization REQUIRED)
 
-if(NOT WIN32)
-  find_package(tcmalloc REQUIRED)
-endif()
-
 if(NOT TARGET console_bridge::console_bridge)
   add_library(console_bridge::console_bridge INTERFACE IMPORTED)
   set_target_properties(console_bridge::console_bridge PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${console_bridge_INCLUDE_DIRS})
@@ -87,9 +83,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
     tesseract::tesseract_motion_planners_descartes
     tesseract::tesseract_motion_planners_ompl
     tesseract::tesseract_time_parameterization)
-if(NOT WIN32)
-  target_link_libraries(${PROJECT_NAME} PUBLIC tcmalloc::tcmalloc)
-endif()
+
 target_compile_options(${PROJECT_NAME} PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME} PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${TESSERACT_COMPILE_DEFINITIONS})

--- a/tesseract_process_managers/test/CMakeLists.txt
+++ b/tesseract_process_managers/test/CMakeLists.txt
@@ -2,6 +2,10 @@ find_package(GTest REQUIRED)
 find_package(tesseract_support REQUIRED)
 find_package(tesseract_kinematics REQUIRED)
 
+if(NOT WIN32)
+  find_package(tcmalloc REQUIRED)
+endif()
+
 if(NOT TARGET GTest::GTest)
   add_library(GTest::GTest INTERFACE IMPORTED)
   set_target_properties(GTest::GTest PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIRS}")
@@ -32,6 +36,10 @@ endif()
 
 include(GoogleTest)
 
+if (NOT WIN32)
+  set(TESSERACT_TCMALLOC_LIB tcmalloc::tcmalloc)
+endif()
+
 add_executable(${PROJECT_NAME}_unit tesseract_process_managers_unit.cpp)
 target_link_libraries(${PROJECT_NAME}_unit PRIVATE GTest::GTest GTest::Main tesseract::tesseract_support tesseract::tesseract_environment_ofkt tesseract::tesseract_kinematics_opw ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}_unit PUBLIC
@@ -45,7 +53,7 @@ add_dependencies(${PROJECT_NAME}_unit ${PROJECT_NAME})
 add_dependencies(run_tests ${PROJECT_NAME}_unit)
 
 add_executable(${PROJECT_NAME}_fix_state_collision_task_generator_unit fix_state_collision_task_generator_unit.cpp)
-target_link_libraries(${PROJECT_NAME}_fix_state_collision_task_generator_unit PRIVATE GTest::GTest GTest::Main tesseract::tesseract_support tesseract::tesseract_environment_ofkt ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}_fix_state_collision_task_generator_unit PRIVATE GTest::GTest GTest::Main tesseract::tesseract_support tesseract::tesseract_environment_ofkt ${PROJECT_NAME} ${TESSERACT_TCMALLOC_LIB})
 target_include_directories(${PROJECT_NAME}_fix_state_collision_task_generator_unit PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/examples>")
 target_compile_options(${PROJECT_NAME}_fix_state_collision_task_generator_unit PRIVATE ${TESSERACT_COMPILE_OPTIONS})
@@ -56,7 +64,7 @@ add_gtest_discover_tests(${PROJECT_NAME}_fix_state_collision_task_generator_unit
 add_dependencies(run_tests ${PROJECT_NAME}_fix_state_collision_task_generator_unit)
 
 add_executable(${PROJECT_NAME}_graph_taskflow_unit graph_taskflow_unit.cpp)
-target_link_libraries(${PROJECT_NAME}_graph_taskflow_unit PUBLIC ${PROJECT_NAME} GTest::GTest GTest::Main)
+target_link_libraries(${PROJECT_NAME}_graph_taskflow_unit PUBLIC ${PROJECT_NAME} GTest::GTest GTest::Main ${TESSERACT_TCMALLOC_LIB})
 target_include_directories(${PROJECT_NAME}_graph_taskflow_unit PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 target_cxx_version(${PROJECT_NAME}_graph_taskflow_unit PRIVATE VERSION ${TESSERACT_CXX_VERSION})


### PR DESCRIPTION
tcmalloc should only be used when linking an executable.

This fixes #25 