### PR TITLE
Fix bug in task info

### DIFF
--- a/tesseract_process_managers/src/core/task_info.cpp
+++ b/tesseract_process_managers/src/core/task_info.cpp
@@ -28,7 +28,7 @@
 
 namespace tesseract_planning
 {
-TaskInfo::TaskInfo(std::size_t unique_id, std::string name) : unique_id(unique_id), message(std::move(name)) {}
+TaskInfo::TaskInfo(std::size_t unique_id, std::string name) : unique_id(unique_id), task_name(std::move(name)) {}
 
 void TaskInfoContainer::addTaskInfo(TaskInfo::ConstPtr task_info)
 {


### PR DESCRIPTION
The name was getting stored in message instead of task_name. I really thought I already fixed this, but maybe it got lost somehow in all the restructuring.