### PR TITLE
Add the ability to save the Task inputs and outputs to the TaskInfo

### DIFF
--- a/tesseract_process_managers/include/tesseract_process_managers/core/task_info.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/task_info.h
@@ -33,6 +33,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <map>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_command_language/core/instruction.h>
+#include <tesseract_command_language/null_instruction.h>
+#include <tesseract_environment/core/environment.h>
+
 #ifdef SWIG
 %shared_ptr(tesseract_planning::TaskInfo)
 %template(TaskInfoMap) std::map<std::size_t, std::shared_ptr<const tesseract_planning::TaskInfo>>;
@@ -64,6 +68,17 @@ public:
   std::string task_name;
 
   std::string message;
+
+  /** @brief Instructions passed to task (optionally set) */
+  Instruction instructions_input{ NullInstruction() };
+  /** @brief Instructions after running the task (optionally set)*/
+  Instruction instructions_output{ NullInstruction() };
+  /** @brief Seed/Results passed into the task (optionally set) */
+  Instruction results_input{ NullInstruction() };
+  /** @brief Seed/Results after running the task (optionally set)*/
+  Instruction results_output{ NullInstruction() };
+  /** @brief This is a clone of the environment at the beginning of the task (optionally set)*/
+  tesseract_environment::Environment::ConstPtr environment{ nullptr };
 };
 
 /** @brief A threadsafe container for TaskInfos */

--- a/tesseract_process_managers/include/tesseract_process_managers/core/task_input.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/task_input.h
@@ -172,6 +172,9 @@ struct TaskInput
   TaskInfo::ConstPtr getTaskInfo(const std::size_t& index) const;
   std::map<std::size_t, TaskInfo::ConstPtr> getTaskInfoMap() const;
 
+  /** @brief If true the task will save the inputs and outputs to the TaskInfo*/
+  bool save_io{ false };
+
 protected:
   /** @brief Instructions to be carried out by process */
   const Instruction* instruction_;

--- a/tesseract_process_managers/include/tesseract_process_managers/core/utils.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/utils.h
@@ -36,6 +36,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_process_managers/core/types.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_process_managers/core/task_input.h>
+#include <tesseract_process_managers/core/task_info.h>
 
 namespace tesseract_planning
 {
@@ -76,6 +77,20 @@ bool isCompositeEmpty(const CompositeInstruction& composite);
  * @return One if seed exists, otherwise zero
  */
 int hasSeedTask(TaskInput input);
+
+/**
+ * @brief Saves the appropriate inputs to the TaskInfo
+ * @param info TaskInfo to which the inputs are saved
+ * @param input TaskInput from which the inputs are taken
+ */
+void saveInputs(TaskInfo::Ptr info, TaskInput& input);
+
+/**
+ * @brief Saves the appropriate outputs to the TaskInfo
+ * @param info TaskInfo to which the outputs are saved
+ * @param input TaskInput from which the outputs are taken
+ */
+void saveOutputs(TaskInfo::Ptr info, TaskInput& input);
 
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/continuous_contact_check_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/continuous_contact_check_task_generator.h
@@ -61,6 +61,9 @@ public:
 class ContinuousContactCheckTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<ContinuousContactCheckTaskInfo>;
+  using ConstPtr = std::shared_ptr<const ContinuousContactCheckTaskInfo>;
+
   ContinuousContactCheckTaskInfo(std::size_t unique_id, std::string name = "Continuous Contact Check Trajectory");
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/discrete_contact_check_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/discrete_contact_check_task_generator.h
@@ -62,6 +62,9 @@ public:
 class DiscreteContactCheckTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<DiscreteContactCheckTaskInfo>;
+  using ConstPtr = std::shared_ptr<const DiscreteContactCheckTaskInfo>;
+
   DiscreteContactCheckTaskInfo(std::size_t unique_id, std::string name = "Discrete Contact Check Trajectory");
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_bounds_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_bounds_task_generator.h
@@ -81,6 +81,9 @@ public:
 class FixStateBoundsTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<FixStateBoundsTaskInfo>;
+  using ConstPtr = std::shared_ptr<const FixStateBoundsTaskInfo>;
+
   FixStateBoundsTaskInfo(std::size_t unique_id, std::string name = "Fix State Bounds");
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_collision_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_collision_task_generator.h
@@ -100,6 +100,9 @@ public:
 class FixStateCollisionTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<FixStateCollisionTaskInfo>;
+  using ConstPtr = std::shared_ptr<const FixStateCollisionTaskInfo>;
+
   FixStateCollisionTaskInfo(std::size_t unique_id, std::string name = "Fix State Collision");
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/iterative_spline_parameterization_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/iterative_spline_parameterization_task_generator.h
@@ -82,6 +82,9 @@ private:
 class IterativeSplineParameterizationTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<IterativeSplineParameterizationTaskInfo>;
+  using ConstPtr = std::shared_ptr<const IterativeSplineParameterizationTaskInfo>;
+
   IterativeSplineParameterizationTaskInfo(std::size_t unique_id,
                                           std::string name = "Iterative Spline Parameterization");
 };

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/motion_planner_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/motion_planner_task_generator.h
@@ -56,6 +56,9 @@ private:
 class MotionPlannerTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<MotionPlannerTaskInfo>;
+  using ConstPtr = std::shared_ptr<const MotionPlannerTaskInfo>;
+
   MotionPlannerTaskInfo(std::size_t unique_id, std::string name = "Motion Planner Process Generator");
 };
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/profile_switch_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/profile_switch_task_generator.h
@@ -72,6 +72,9 @@ public:
 class ProfileSwitchTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<ProfileSwitchTaskInfo>;
+  using ConstPtr = std::shared_ptr<const ProfileSwitchTaskInfo>;
+
   ProfileSwitchTaskInfo(std::size_t unique_id, std::string name = "Profile Switch");
 };
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/seed_min_length_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/seed_min_length_task_generator.h
@@ -67,6 +67,9 @@ private:
 class SeedMinLengthTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<SeedMinLengthTaskInfo>;
+  using ConstPtr = std::shared_ptr<const SeedMinLengthTaskInfo>;
+
   SeedMinLengthTaskInfo(std::size_t unique_id, std::string name = "Seed Min Length");
 };
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/time_optimal_trajectory_generation_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/time_optimal_trajectory_generation_task_generator.h
@@ -91,6 +91,9 @@ public:
 class TimeOptimalTrajectoryGenerationTaskInfo : public TaskInfo
 {
 public:
+  using Ptr = std::shared_ptr<TimeOptimalTrajectoryGenerationTaskInfo>;
+  using ConstPtr = std::shared_ptr<const TimeOptimalTrajectoryGenerationTaskInfo>;
+
   TimeOptimalTrajectoryGenerationTaskInfo(std::size_t unique_id, std::string name = "TOTG");
 };
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/core/utils.cpp
+++ b/tesseract_process_managers/src/core/utils.cpp
@@ -88,4 +88,23 @@ int hasSeedTask(TaskInput input)
   }
   return 1;
 }
+
+void saveInputs(TaskInfo::Ptr info, TaskInput& input)
+{
+  if (input.save_io)
+  {
+    info->environment = input.env->clone();
+    info->instructions_input = *input.getInstruction();
+    info->results_input = *input.getResults();
+  }
+}
+
+void saveOutputs(TaskInfo::Ptr info, TaskInput& input)
+{
+  if (input.save_io)
+  {
+    info->instructions_output = *input.getInstruction();
+    info->results_output = *input.getResults();
+  }
+}
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/continuous_contact_check_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/continuous_contact_check_task_generator.cpp
@@ -29,6 +29,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_process_managers/core/utils.h>
 #include <tesseract_process_managers/task_generators/continuous_contact_check_task_generator.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_motion_planners/core/utils.h>
@@ -66,6 +67,7 @@ int ContinuousContactCheckTaskGenerator::conditionalProcess(TaskInput input, std
   auto info = std::make_shared<ContinuousContactCheckTaskInfo>(unique_id, name_);
   info->return_value = 0;
   input.addTaskInfo(info);
+  saveInputs(info, input);
 
   // --------------------
   // Check that inputs are valid
@@ -75,6 +77,7 @@ int ContinuousContactCheckTaskGenerator::conditionalProcess(TaskInput input, std
   {
     info->message = "Input seed to ContinuousContactCheckTaskGenerator must be a composite instruction";
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
+    saveOutputs(info, input);
     return 0;
   }
 
@@ -109,11 +112,13 @@ int ContinuousContactCheckTaskGenerator::conditionalProcess(TaskInput input, std
                                    contact.link_names[1] + " Dist: " + std::to_string(contact.distance))
                                       .c_str());
     info->contact_results = contacts;
+    saveOutputs(info, input);
     return 0;
   }
 
   CONSOLE_BRIDGE_logDebug("Continuous contact check succeeded");
   info->return_value = 1;
+  saveOutputs(info, input);
   return 1;
 }
 

--- a/tesseract_process_managers/src/task_generators/discrete_contact_check_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/discrete_contact_check_task_generator.cpp
@@ -29,6 +29,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_process_managers/core/utils.h>
 #include <tesseract_process_managers/task_generators/discrete_contact_check_task_generator.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_motion_planners/core/utils.h>
@@ -65,6 +66,7 @@ int DiscreteContactCheckTaskGenerator::conditionalProcess(TaskInput input, std::
   auto info = std::make_shared<DiscreteContactCheckTaskInfo>(unique_id, name_);
   info->return_value = 0;
   input.addTaskInfo(info);
+  saveInputs(info, input);
 
   // --------------------
   // Check that inputs are valid
@@ -74,6 +76,7 @@ int DiscreteContactCheckTaskGenerator::conditionalProcess(TaskInput input, std::
   {
     info->message = "Input seed to DiscreteContactCheckTaskGenerator must be a composite instruction";
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
+    saveOutputs(info, input);
     return 0;
   }
 
@@ -108,11 +111,13 @@ int DiscreteContactCheckTaskGenerator::conditionalProcess(TaskInput input, std::
                                    contact.link_names[1] + " Dist: " + std::to_string(contact.distance))
                                       .c_str());
     info->contact_results = contacts;
+    saveOutputs(info, input);
     return 0;
   }
 
   CONSOLE_BRIDGE_logDebug("Discrete contact check succeeded");
   info->return_value = 1;
+  saveOutputs(info, input);
   return 1;
 }
 

--- a/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
@@ -30,6 +30,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/planner_utils.h>
+#include <tesseract_process_managers/core/utils.h>
 #include <tesseract_process_managers/task_generators/iterative_spline_parameterization_task_generator.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_command_language/move_instruction.h>
@@ -62,6 +63,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   auto info = std::make_shared<IterativeSplineParameterizationTaskInfo>(unique_id, name_);
   info->return_value = 0;
   input.addTaskInfo(info);
+  saveInputs(info, input);
 
   // --------------------
   // Check that inputs are valid
@@ -70,6 +72,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   if (!isCompositeInstruction(*input_results))
   {
     CONSOLE_BRIDGE_logError("Input results to iterative spline parameterization must be a composite instruction");
+    saveOutputs(info, input);
     return 0;
   }
 
@@ -91,6 +94,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   {
     CONSOLE_BRIDGE_logWarn("Iterative spline time parameterization found no MoveInstructions to process");
     info->return_value = 1;
+    saveOutputs(info, input);
     return 1;
   }
 
@@ -127,11 +131,13 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   {
     CONSOLE_BRIDGE_logInform("Failed to perform iterative spline time parameterization for process input: %s!",
                              input_results->getDescription().c_str());
+    saveOutputs(info, input);
     return 0;
   }
 
   CONSOLE_BRIDGE_logDebug("Iterative spline time parameterization succeeded");
   info->return_value = 1;
+  saveOutputs(info, input);
   return 1;
 }
 

--- a/tesseract_process_managers/src/task_generators/motion_planner_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/motion_planner_task_generator.cpp
@@ -29,6 +29,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_process_managers/core/utils.h>
 #include <tesseract_process_managers/task_generators/motion_planner_task_generator.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_command_language/utils/get_instruction_utils.h>
@@ -49,6 +50,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   auto info = std::make_shared<MotionPlannerTaskInfo>(unique_id, name_);
   info->return_value = 0;
   input.addTaskInfo(info);
+  saveInputs(info, input);
 
   // --------------------
   // Check that inputs are valid
@@ -58,6 +60,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   {
     info->message = "Input instructions to MotionPlannerTaskGenerator: " + name_ + " must be a composite instruction";
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
+    saveOutputs(info, input);
     return 0;
   }
 
@@ -66,6 +69,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   {
     info->message = "Input seed to MotionPlannerTaskGenerator: " + name_ + " must be a composite instruction";
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
+    saveOutputs(info, input);
     return 0;
   }
 
@@ -167,6 +171,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
     *input_results = response.results;
     CONSOLE_BRIDGE_logDebug("Motion Planner process succeeded");
     info->return_value = 1;
+    saveOutputs(info, input);
     return 1;
   }
 
@@ -175,6 +180,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
                            status.message().c_str(),
                            input_instruction->getDescription().c_str());
   info->message = status.message();
+  saveOutputs(info, input);
   return 0;
 }
 

--- a/tesseract_process_managers/src/task_generators/profile_switch_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/profile_switch_task_generator.cpp
@@ -27,6 +27,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_process_managers/core/utils.h>
 #include <tesseract_process_managers/task_generators/profile_switch_task_generator.h>
 #include <tesseract_command_language/constants.h>
 #include <tesseract_command_language/utils/utils.h>
@@ -50,6 +51,7 @@ int ProfileSwitchTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   auto info = std::make_shared<ProfileSwitchTaskInfo>(unique_id, name_);
   info->return_value = 0;
   input.addTaskInfo(info);
+  saveInputs(info, input);
 
   // --------------------
   // Check that inputs are valid
@@ -58,6 +60,7 @@ int ProfileSwitchTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   if (!isCompositeInstruction(*input_instruction))
   {
     CONSOLE_BRIDGE_logError("Input instruction to ProfileSwitch must be a composite instruction. Returning 0");
+    saveOutputs(info, input);
     return 0;
   }
 

--- a/tesseract_process_managers/src/task_generators/seed_min_length_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/seed_min_length_task_generator.cpp
@@ -30,6 +30,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_process_managers/core/utils.h>
 #include <tesseract_process_managers/task_generators/seed_min_length_task_generator.h>
 #include <tesseract_motion_planners/core/utils.h>
 #include <tesseract_command_language/utils/get_instruction_utils.h>
@@ -56,12 +57,14 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   auto info = std::make_shared<SeedMinLengthTaskInfo>(unique_id, name_);
   info->return_value = 0;
   input.addTaskInfo(info);
+  saveInputs(info, input);
 
   // Check that inputs are valid
   Instruction* input_results = input.getResults();
   if (!isCompositeInstruction(*input_results))
   {
     CONSOLE_BRIDGE_logError("Input seed to SeedMinLengthTaskGenerator must be a composite instruction");
+    saveOutputs(info, input);
     return 0;
   }
 
@@ -70,6 +73,7 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   if (cnt >= min_length_)
   {
     info->return_value = 1;
+    saveOutputs(info, input);
     return 1;
   }
 
@@ -85,6 +89,7 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
 
   CONSOLE_BRIDGE_logDebug("Seed Min Length Process Generator Succeeded!");
   info->return_value = 1;
+  saveOutputs(info, input);
   return 1;
 }
 

--- a/tesseract_process_managers/src/task_generators/time_optimal_trajectory_generation_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/time_optimal_trajectory_generation_task_generator.cpp
@@ -31,6 +31,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/planner_utils.h>
+#include <tesseract_process_managers/core/utils.h>
 #include <tesseract_process_managers/task_generators/time_optimal_trajectory_generation_task_generator.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_command_language/move_instruction.h>
@@ -68,6 +69,7 @@ int TimeOptimalTrajectoryGenerationTaskGenerator::conditionalProcess(TaskInput i
   auto info = std::make_shared<TimeOptimalTrajectoryGenerationTaskInfo>(unique_id, name_);
   info->return_value = 0;
   input.addTaskInfo(info);
+  saveInputs(info, input);
 
   // --------------------
   // Check that inputs are valid
@@ -76,6 +78,7 @@ int TimeOptimalTrajectoryGenerationTaskGenerator::conditionalProcess(TaskInput i
   if (!isCompositeInstruction(*input_results))
   {
     CONSOLE_BRIDGE_logError("Input results to TOTG must be a composite instruction");
+    saveOutputs(info, input);
     return 0;
   }
 
@@ -97,6 +100,7 @@ int TimeOptimalTrajectoryGenerationTaskGenerator::conditionalProcess(TaskInput i
   {
     CONSOLE_BRIDGE_logWarn("TOTG found no MoveInstructions to process");
     info->return_value = 1;
+    saveOutputs(info, input);
     return 1;
   }
 
@@ -134,11 +138,13 @@ int TimeOptimalTrajectoryGenerationTaskGenerator::conditionalProcess(TaskInput i
                                 acceleration_scaling_factors))
   {
     CONSOLE_BRIDGE_logInform("Failed to perform TOTG for process input: %s!", input_results->getDescription().c_str());
+    saveOutputs(info, input);
     return 0;
   }
 
   CONSOLE_BRIDGE_logDebug("TOTG succeeded");
   info->return_value = 1;
+  saveOutputs(info, input);
   return 1;
 }
 


### PR DESCRIPTION
The plan is to next add serialization functions in tesseract_ros that can lump all the TaskInfos from a Tasflow into a directory and maybe zip it up. Then ideally we would create an RVIZ widget to allow us to open that file/directory and navigate through all of the TaskInfos and select which one to visualize.