### PR TITLE
Add trajectory container class to abstract command lanaguage from time parameterization

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/core/instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/core/instruction.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/export.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/unique_ptr.hpp>
+#include <boost/serialization/export.hpp>
 #include <boost/type_traits/is_virtual_base_of.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_command_language/include/tesseract_command_language/core/waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/core/waypoint.h
@@ -35,6 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/export.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/unique_ptr.hpp>
+#include <boost/serialization/export.hpp>
 #include <boost/type_traits/is_virtual_base_of.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
@@ -129,7 +129,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   }
 
   // Solve using parameters
-  TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(*ci);
+  TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(ci);
   if (!solver_.compute(*trajectory,
                        fwd_kin->getLimits().velocity_limits,
                        fwd_kin->getLimits().acceleration_limits,

--- a/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
@@ -38,6 +38,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/utils/filter_functions.h>
 #include <tesseract_command_language/utils/flatten_utils.h>
 #include <tesseract_time_parameterization/iterative_spline_parameterization.h>
+#include <tesseract_time_parameterization/instructions_trajectory.h>
 
 namespace tesseract_planning
 {
@@ -128,7 +129,8 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   }
 
   // Solve using parameters
-  if (!solver_.compute(ci,
+  TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(*ci);
+  if (!solver_.compute(*trajectory,
                        fwd_kin->getLimits().velocity_limits,
                        fwd_kin->getLimits().acceleration_limits,
                        velocity_scaling_factors,

--- a/tesseract_time_parameterization/CMakeLists.txt
+++ b/tesseract_time_parameterization/CMakeLists.txt
@@ -33,6 +33,7 @@ add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE})
 tesseract_variables()
 
 add_library(${PROJECT_NAME}
+    src/instructions_trajectory.cpp
     src/iterative_spline_parameterization
     src/time_optimal_trajectory_generation
     )

--- a/tesseract_time_parameterization/include/tesseract_time_parameterization/instructions_trajectory.h
+++ b/tesseract_time_parameterization/include/tesseract_time_parameterization/instructions_trajectory.h
@@ -1,0 +1,61 @@
+/**
+ * @file instructions_trajectory.h
+ * @brief Trajectory Container implementation for command language instructions
+ *
+ * @author Levi Armstrong
+ * @date March 3, 2021
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2021, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_TIME_PARAMETERIZATION_INSTRUCTIONS_TRAJECTORY_H
+#define TESSERACT_TIME_PARAMETERIZATION_INSTRUCTIONS_TRAJECTORY_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <vector>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_time_parameterization/trajectory_container.h>
+#include <tesseract_command_language/core/instruction.h>
+#include <tesseract_command_language/composite_instruction.h>
+
+namespace tesseract_planning
+{
+class InstructionsTrajectory : public TrajectoryContainer
+{
+public:
+  InstructionsTrajectory(std::vector<std::reference_wrapper<Instruction>> trajectory);
+  InstructionsTrajectory(CompositeInstruction& program);
+
+  const Eigen::VectorXd& getPosition(Eigen::Index i) const;
+  const Eigen::VectorXd& getVelocity(Eigen::Index i) const;
+  const Eigen::VectorXd& getAcceleration(Eigen::Index i) const;
+
+  void setData(Eigen::Index i, const Eigen::VectorXd& velocity, const Eigen::VectorXd& acceleration, double time);
+
+  Eigen::Index size() const;
+  Eigen::Index dof() const;
+  bool empty() const;
+
+private:
+  std::vector<std::reference_wrapper<Instruction>> trajectory_;
+  Eigen::Index dof_;
+};
+}  // namespace tesseract_planning
+#endif  // TESSERACT_TIME_PARAMETERIZATION_INSTRUCTIONS_TRAJECTORY_H

--- a/tesseract_time_parameterization/include/tesseract_time_parameterization/instructions_trajectory.h
+++ b/tesseract_time_parameterization/include/tesseract_time_parameterization/instructions_trajectory.h
@@ -43,15 +43,15 @@ public:
   InstructionsTrajectory(std::vector<std::reference_wrapper<Instruction>> trajectory);
   InstructionsTrajectory(CompositeInstruction& program);
 
-  const Eigen::VectorXd& getPosition(Eigen::Index i) const;
-  const Eigen::VectorXd& getVelocity(Eigen::Index i) const;
-  const Eigen::VectorXd& getAcceleration(Eigen::Index i) const;
+  const Eigen::VectorXd& getPosition(Eigen::Index i) const final;
+  const Eigen::VectorXd& getVelocity(Eigen::Index i) const final;
+  const Eigen::VectorXd& getAcceleration(Eigen::Index i) const final;
 
-  void setData(Eigen::Index i, const Eigen::VectorXd& velocity, const Eigen::VectorXd& acceleration, double time);
+  void setData(Eigen::Index i, const Eigen::VectorXd& velocity, const Eigen::VectorXd& acceleration, double time) final;
 
-  Eigen::Index size() const;
-  Eigen::Index dof() const;
-  bool empty() const;
+  Eigen::Index size() const final;
+  Eigen::Index dof() const final;
+  bool empty() const final;
 
 private:
   std::vector<std::reference_wrapper<Instruction>> trajectory_;

--- a/tesseract_time_parameterization/include/tesseract_time_parameterization/iterative_spline_parameterization.h
+++ b/tesseract_time_parameterization/include/tesseract_time_parameterization/iterative_spline_parameterization.h
@@ -43,7 +43,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Eigen>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_command_language/command_language.h>
+#include <tesseract_time_parameterization/trajectory_container.h>
 
 namespace tesseract_planning
 {
@@ -85,78 +85,6 @@ public:
   IterativeSplineParameterization& operator=(IterativeSplineParameterization&&) = default;
 
   /**
-   * @brief Compute the time stamps for a provided program.
-   *
-   * This will flatten the program to a vector of move instructions
-   *
-   * @param program The program to compute time stamps
-   * @param max_velocities The max velocities for each joint
-   * @param max_accelerations The max acceleration for each joint
-   * @param max_velocity_scaling_factor The max velocity scaling factor
-   * @param max_acceleration_scaling_factor The max acceleration scaling factor
-   * @return True if successful, otherwise false
-   */
-  bool compute(CompositeInstruction& program,
-               const double& max_velocity,
-               const double& max_acceleration,
-               double max_velocity_scaling_factor = 1.0,
-               double max_acceleration_scaling_factor = 1.0) const;
-
-  /**
-   * @brief Compute the time stamps for a provided program.
-   *
-   * This will flatten the program to a vector of move instructions
-   *
-   * @param program The program to compute time stamps
-   * @param max_velocities The max velocities for each joint
-   * @param max_accelerations The max acceleration for each joint
-   * @param max_velocity_scaling_factor The max velocity scaling factor
-   * @param max_acceleration_scaling_factor The max acceleration scaling factor
-   * @return True if successful, otherwise false
-   */
-  bool compute(CompositeInstruction& program,
-               const std::vector<double>& max_velocity,
-               const std::vector<double>& max_acceleration,
-               double max_velocity_scaling_factor = 1.0,
-               double max_acceleration_scaling_factor = 1.0) const;
-
-  /**
-   * @brief Compute the time stamps for a provided program.
-   *
-   * This will flatten the program to a vector of move instructions
-   *
-   * @param program The program to compute time stamps
-   * @param max_velocities The max velocities for each joint
-   * @param max_accelerations The max acceleration for each joint
-   * @param max_velocity_scaling_factor The max velocity scaling factor
-   * @param max_acceleration_scaling_factor The max acceleration scaling factor
-   * @return True if successful, otherwise false
-   */
-  bool compute(CompositeInstruction& program,
-               const Eigen::Ref<const Eigen::VectorXd>& max_velocity,
-               const Eigen::Ref<const Eigen::VectorXd>& max_acceleration,
-               double max_velocity_scaling_factor = 1.0,
-               double max_acceleration_scaling_factor = 1.0) const;
-
-  /**
-   * @brief Compute the time stamps for a provided program.
-   *
-   * This will flatten the program to a vector of move instructions
-   *
-   * @param program The program to compute time stamps
-   * @param max_velocities The max velocities for each joint
-   * @param max_accelerations The max acceleration for each joint
-   * @param max_velocity_scaling_factor The max velocity scaling factor. Size should be program.size()
-   * @param max_acceleration_scaling_factor The max acceleration scaling factor. Size should be program.size()
-   * @return True if successful, otherwise false
-   */
-  bool compute(CompositeInstruction& program,
-               const Eigen::Ref<const Eigen::VectorXd>& max_velocity,
-               const Eigen::Ref<const Eigen::VectorXd>& max_acceleration,
-               const Eigen::Ref<const Eigen::VectorXd>& max_velocity_scaling_factor,
-               const Eigen::Ref<const Eigen::VectorXd>& max_acceleration_scaling_factor) const;
-
-  /**
    * @brief Compute the time stamps for a flattened vector of move instruction
    * @param trajectory Flattended vector of move instruction
    * @param max_velocities The max velocities for each joint
@@ -165,7 +93,7 @@ public:
    * @param max_acceleration_scaling_factor The max acceleration scaling factor
    * @return True if successful, otherwise false
    */
-  bool compute(std::vector<std::reference_wrapper<Instruction>>& trajectory,
+  bool compute(TrajectoryContainer& trajectory,
                const double& max_velocity,
                const double& max_acceleration,
                double max_velocity_scaling_factor = 1.0,
@@ -180,7 +108,7 @@ public:
    * @param max_acceleration_scaling_factor The max acceleration scaling factor
    * @return True if successful, otherwise false
    */
-  bool compute(std::vector<std::reference_wrapper<Instruction>>& trajectory,
+  bool compute(TrajectoryContainer& trajectory,
                const std::vector<double>& max_velocity,
                const std::vector<double>& max_acceleration,
                double max_velocity_scaling_factor = 1.0,
@@ -195,7 +123,7 @@ public:
    * @param max_acceleration_scaling_factor The max acceleration scaling factor
    * @return True if successful, otherwise false
    */
-  bool compute(std::vector<std::reference_wrapper<Instruction>>& trajectory,
+  bool compute(TrajectoryContainer& trajectory,
                const Eigen::Ref<const Eigen::VectorXd>& max_velocity,
                const Eigen::Ref<const Eigen::VectorXd>& max_acceleration,
                double max_velocity_scaling_factor = 1.0,
@@ -210,7 +138,7 @@ public:
    * @param max_acceleration_scaling_factor The max acceleration scaling factor. Size should be trajectory.size()
    * @return True if successful, otherwise false
    */
-  bool compute(std::vector<std::reference_wrapper<Instruction>>& trajectory,
+  bool compute(TrajectoryContainer& trajectory,
                const Eigen::Ref<const Eigen::VectorXd>& max_velocity,
                const Eigen::Ref<const Eigen::VectorXd>& max_acceleration,
                const Eigen::Ref<const Eigen::VectorXd>& max_velocity_scaling_factors,

--- a/tesseract_time_parameterization/include/tesseract_time_parameterization/time_optimal_trajectory_generation.h
+++ b/tesseract_time_parameterization/include/tesseract_time_parameterization/time_optimal_trajectory_generation.h
@@ -46,6 +46,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/command_language.h>
+#include <tesseract_time_parameterization/trajectory_container.h>
 
 #ifdef SWIG
 %shared_ptr(tesseract_planning::TimeOptimalTrajectoryGeneration)
@@ -61,6 +62,12 @@ public:
                                   double min_angle_change = 0.001);
 
   bool computeTimeStamps(CompositeInstruction& program,
+                         const Eigen::Ref<const Eigen::VectorXd>& max_velocity,
+                         const Eigen::Ref<const Eigen::VectorXd>& max_acceleration,
+                         double max_velocity_scaling_factor = 1.0,
+                         double max_acceleration_scaling_factor = 1.0) const;
+
+  bool computeTimeStamps(TrajectoryContainer& trajectory,
                          const Eigen::Ref<const Eigen::VectorXd>& max_velocity,
                          const Eigen::Ref<const Eigen::VectorXd>& max_acceleration,
                          double max_velocity_scaling_factor = 1.0,
@@ -156,6 +163,18 @@ public:
   Eigen::VectorXd getVelocity(double time) const;
   /** @brief Return the acceleration vector for a given point in time */
   Eigen::VectorXd getAcceleration(double time) const;
+
+  /**
+   * @brief Assign trajectory velocity acceleration and time
+   * @details This search linear in time for the next waypoint within the provided tolerance
+   */
+  bool assignData(TrajectoryContainer& trajectory, double path_tolerance) const;
+
+  /**
+   * @brief Assign trajectory velocity acceleration and time
+   * @details This is brute force approach and should always return true
+   */
+  bool assignData(TrajectoryContainer& trajectory) const;
 
 private:
   struct TrajectoryStep

--- a/tesseract_time_parameterization/include/tesseract_time_parameterization/trajectory_container.h
+++ b/tesseract_time_parameterization/include/tesseract_time_parameterization/trajectory_container.h
@@ -1,0 +1,88 @@
+/**
+ * @file trajectory_container.h
+ * @brief Creates an interface for contaning different trajectory data structures
+ *
+ * @author Levi Armstrong
+ * @date March 3, 2021
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2021, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_TIME_PARAMETERIZATION_TRAJECTORY_CONTAINER_H
+#define TESSERACT_TIME_PARAMETERIZATION_TRAJECTORY_CONTAINER_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <Eigen/Eigen>
+#include <memory>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_planning
+{
+/** @brief A generic container that the time parameterization classes use */
+class TrajectoryContainer
+{
+public:
+  using Ptr = std::shared_ptr<TrajectoryContainer>;
+  using ConstPtr = std::shared_ptr<const TrajectoryContainer>;
+
+  virtual ~TrajectoryContainer() = default;
+
+  /**
+   * @brief Get the position data at a given index
+   * @param i The index to extract position data
+   * @return The position data
+   */
+  virtual const Eigen::VectorXd& getPosition(Eigen::Index i) const = 0;
+
+  /**
+   * @brief Get the velocity data at a given index
+   * @param i The index to extract velocity data
+   * @return The velocity data
+   */
+  virtual const Eigen::VectorXd& getVelocity(Eigen::Index i) const = 0;
+
+  /**
+   * @brief Get the acceleration data at a given index
+   * @param i The index to extract acceleration data
+   * @return The acceleration data
+   */
+  virtual const Eigen::VectorXd& getAcceleration(Eigen::Index i) const = 0;
+
+  /**
+   * @brief Set data for a given index
+   * @param i The index to set data
+   * @param velocity The velocity data to assign to index
+   * @param acceleration The acceleration data to assign to index
+   * @param time The time from start to assign to index
+   */
+  virtual void
+  setData(Eigen::Index i, const Eigen::VectorXd& velocity, const Eigen::VectorXd& acceleration, double time) = 0;
+
+  /** @brief The size of the path */
+  virtual Eigen::Index size() const = 0;
+
+  /** @brief The degree of freedom for the path */
+  virtual Eigen::Index dof() const = 0;
+
+  /** @brief Check if the path is empty */
+  virtual bool empty() const = 0;
+};
+
+}  // namespace tesseract_planning
+#endif  // TESSERACT_TIME_PARAMETERIZATION_TRAJECTORY_CONTAINER_H

--- a/tesseract_time_parameterization/include/tesseract_time_parameterization/trajectory_container.h
+++ b/tesseract_time_parameterization/include/tesseract_time_parameterization/trajectory_container.h
@@ -41,7 +41,12 @@ public:
   using Ptr = std::shared_ptr<TrajectoryContainer>;
   using ConstPtr = std::shared_ptr<const TrajectoryContainer>;
 
+  TrajectoryContainer() = default;
   virtual ~TrajectoryContainer() = default;
+  TrajectoryContainer(const TrajectoryContainer&) = default;
+  TrajectoryContainer& operator=(const TrajectoryContainer&) = default;
+  TrajectoryContainer(TrajectoryContainer&&) noexcept = default;
+  TrajectoryContainer& operator=(TrajectoryContainer&&) noexcept = default;
 
   /**
    * @brief Get the position data at a given index

--- a/tesseract_time_parameterization/src/instructions_trajectory.cpp
+++ b/tesseract_time_parameterization/src/instructions_trajectory.cpp
@@ -1,0 +1,123 @@
+/**
+ * @file instructions_trajectory.cpp
+ * @brief Trajectory Container implementation for command language instructions
+ *
+ * @author Levi Armstrong
+ * @date March 3, 2021
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2021, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_time_parameterization/instructions_trajectory.h>
+#include <tesseract_command_language/utils/utils.h>
+#include <tesseract_command_language/state_waypoint.h>
+
+namespace tesseract_planning
+{
+static flattenFilterFn programFlattenMoveInstructionFilter =
+    [](const Instruction& i, const CompositeInstruction& /*composite*/, bool parent_is_first_composite) {
+      if (isMoveInstruction(i))
+      {
+        if (i.cast_const<MoveInstruction>()->isStart())
+          return (parent_is_first_composite);
+
+        return true;
+      }
+
+      return false;
+    };
+
+InstructionsTrajectory::InstructionsTrajectory(std::vector<std::reference_wrapper<Instruction>> trajectory)
+  : trajectory_(std::move(trajectory))
+{
+  dof_ = trajectory_.front()
+             .get()
+             .cast_const<MoveInstruction>()
+             ->getWaypoint()
+             .cast_const<StateWaypoint>()
+             ->position.rows();
+}
+
+InstructionsTrajectory::InstructionsTrajectory(CompositeInstruction& program)
+{
+  trajectory_ = flatten(program, programFlattenMoveInstructionFilter);
+  dof_ = trajectory_.front()
+             .get()
+             .cast_const<MoveInstruction>()
+             ->getWaypoint()
+             .cast_const<StateWaypoint>()
+             ->position.rows();
+}
+
+const Eigen::VectorXd& InstructionsTrajectory::getPosition(Eigen::Index i) const
+{
+  assert(isMoveInstruction(trajectory_[static_cast<std::size_t>(i)].get()));
+  assert(isStateWaypoint(trajectory_[static_cast<std::size_t>(i)].get().cast_const<MoveInstruction>()->getWaypoint()));
+  return trajectory_[static_cast<std::size_t>(i)]
+      .get()
+      .cast_const<MoveInstruction>()
+      ->getWaypoint()
+      .cast_const<StateWaypoint>()
+      ->position;
+}
+const Eigen::VectorXd& InstructionsTrajectory::getVelocity(Eigen::Index i) const
+{
+  assert(isMoveInstruction(trajectory_[static_cast<std::size_t>(i)].get()));
+  assert(isStateWaypoint(trajectory_[static_cast<std::size_t>(i)].get().cast_const<MoveInstruction>()->getWaypoint()));
+  return trajectory_[static_cast<std::size_t>(i)]
+      .get()
+      .cast_const<MoveInstruction>()
+      ->getWaypoint()
+      .cast_const<StateWaypoint>()
+      ->velocity;
+}
+
+const Eigen::VectorXd& InstructionsTrajectory::getAcceleration(Eigen::Index i) const
+{
+  assert(isMoveInstruction(trajectory_[static_cast<std::size_t>(i)].get()));
+  assert(isStateWaypoint(trajectory_[static_cast<std::size_t>(i)].get().cast_const<MoveInstruction>()->getWaypoint()));
+  return trajectory_[static_cast<std::size_t>(i)]
+      .get()
+      .cast_const<MoveInstruction>()
+      ->getWaypoint()
+      .cast_const<StateWaypoint>()
+      ->acceleration;
+}
+
+void InstructionsTrajectory::setData(Eigen::Index i,
+                                     const Eigen::VectorXd& velocity,
+                                     const Eigen::VectorXd& acceleration,
+                                     double time)
+{
+  assert(isMoveInstruction(trajectory_[static_cast<std::size_t>(i)].get()));
+  assert(isStateWaypoint(trajectory_[static_cast<std::size_t>(i)].get().cast_const<MoveInstruction>()->getWaypoint()));
+  StateWaypoint* swp =
+      trajectory_[static_cast<std::size_t>(i)].get().cast<MoveInstruction>()->getWaypoint().cast<StateWaypoint>();
+  swp->velocity = velocity;
+  swp->acceleration = acceleration;
+  swp->time = time;
+}
+
+Eigen::Index InstructionsTrajectory::size() const { return static_cast<Eigen::Index>(trajectory_.size()); }
+
+Eigen::Index InstructionsTrajectory::dof() const { return dof_; }
+
+bool InstructionsTrajectory::empty() const { return trajectory_.empty(); }
+
+}  // namespace tesseract_planning

--- a/tesseract_time_parameterization/src/iterative_spline_parameterization.cpp
+++ b/tesseract_time_parameterization/src/iterative_spline_parameterization.cpp
@@ -47,7 +47,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-
 static void fit_cubic_spline(const long n, const double dt[], const double x[], double x1[], double x2[]);
 static void adjust_two_positions(const long n,
                                  const double dt[],

--- a/tesseract_time_parameterization/src/time_optimal_trajectory_generation.cpp
+++ b/tesseract_time_parameterization/src/time_optimal_trajectory_generation.cpp
@@ -291,7 +291,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(TrajectoryContainer& tra
   // Have to convert into Eigen data structs and remove repeated points
   //  (https://github.com/tobiaskunz/trajectories/issues/3)
   std::list<Eigen::VectorXd> points;
-  for (Eigen::Index p = 0; p < num_points; ++p)
+  for (Eigen::Index p = 0; p < static_cast<Eigen::Index>(num_points); ++p)
   {
     const Eigen::VectorXd& position = trajectory.getPosition(p);
     bool diverse_point = (p == 0);

--- a/tesseract_time_parameterization/test/iterative_spline_tests.cpp
+++ b/tesseract_time_parameterization/test/iterative_spline_tests.cpp
@@ -42,6 +42,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_time_parameterization/iterative_spline_parameterization.h>
+#include <tesseract_time_parameterization/instructions_trajectory.h>
 
 using namespace tesseract_planning;
 
@@ -103,8 +104,9 @@ TEST(TestTimeParameterization, TestIterativeSpline)
   CompositeInstruction program = createStraightTrajectory();
   std::vector<double> max_velocity = { 2.088, 2.082, 3.27, 3.6, 3.3, 3.078 };
   std::vector<double> max_acceleration = { 1, 1, 1, 1, 1, 1 };
-  EXPECT_TRUE(time_parameterization.compute(program, max_velocity, max_acceleration));
-  ASSERT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 5.0);
+  TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
+  EXPECT_TRUE(time_parameterization.compute(*trajectory, max_velocity, max_acceleration));
+  ASSERT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 5.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
@@ -113,8 +115,9 @@ TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
   CompositeInstruction program = createStraightTrajectory();
   std::vector<double> max_velocity = { 2.088, 2.082, 3.27, 3.6, 3.3, 3.078 };
   std::vector<double> max_acceleration = { 1, 1, 1, 1, 1, 1 };
-  EXPECT_TRUE(time_parameterization.compute(program, max_velocity, max_acceleration));
-  ASSERT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 5.0);
+  TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
+  EXPECT_TRUE(time_parameterization.compute(*trajectory, max_velocity, max_acceleration));
+  ASSERT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 5.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineDynamicParams)
@@ -126,18 +129,22 @@ TEST(TestTimeParameterization, TestIterativeSplineDynamicParams)
   Eigen::VectorXd max_acceleration(6);
   max_acceleration << 1, 1, 1, 1, 1, 1;
   Eigen::VectorXd max_velocity_scaling_factors = Eigen::VectorXd::Ones(static_cast<Eigen::Index>(program.size() + 1));
-  Eigen::VectorXd max_acceleration_scaling_factors =
-      Eigen::VectorXd::Ones(static_cast<Eigen::Index>(program.size() + 1));  // +1 for start instruction
 
+  // +1 for start instruction
+  Eigen::VectorXd max_acceleration_scaling_factors =
+      Eigen::VectorXd::Ones(static_cast<Eigen::Index>(program.size() + 1));
+
+  TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
   EXPECT_TRUE(time_parameterization.compute(
-      program, max_velocity, max_acceleration, max_velocity_scaling_factors, max_acceleration_scaling_factors));
-  EXPECT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 5.0);
+      *trajectory, max_velocity, max_acceleration, max_velocity_scaling_factors, max_acceleration_scaling_factors));
+  EXPECT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 5.0);
 
   program = createStraightTrajectory();
   max_velocity_scaling_factors[0] = 0.5;
   max_acceleration_scaling_factors[0] = 0.5;
+  trajectory = std::make_shared<InstructionsTrajectory>(program);
   EXPECT_TRUE(time_parameterization.compute(
-      program, max_velocity, max_acceleration, max_velocity_scaling_factors, max_acceleration_scaling_factors));
+      *trajectory, max_velocity, max_acceleration, max_velocity_scaling_factors, max_acceleration_scaling_factors));
 }
 
 TEST(TestTimeParameterization, TestRepeatedPoint)
@@ -146,8 +153,9 @@ TEST(TestTimeParameterization, TestRepeatedPoint)
   CompositeInstruction program = createRepeatedPointTrajectory();
   std::vector<double> max_velocity = { 2.088, 2.082, 3.27, 3.6, 3.3, 3.078 };
   std::vector<double> max_acceleration = { 1, 1, 1, 1, 1, 1 };
-  EXPECT_TRUE(time_parameterization.compute(program, max_velocity, max_acceleration));
-  ASSERT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 0.001);
+  TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
+  EXPECT_TRUE(time_parameterization.compute(*trajectory, max_velocity, max_acceleration));
+  ASSERT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 0.001);
 }
 
 int main(int argc, char** argv)

--- a/tesseract_time_parameterization/test/iterative_spline_tests.cpp
+++ b/tesseract_time_parameterization/test/iterative_spline_tests.cpp
@@ -106,7 +106,7 @@ TEST(TestTimeParameterization, TestIterativeSpline)
   std::vector<double> max_acceleration = { 1, 1, 1, 1, 1, 1 };
   TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
   EXPECT_TRUE(time_parameterization.compute(*trajectory, max_velocity, max_acceleration));
-  ASSERT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 5.0);
+  ASSERT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 5.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
@@ -117,7 +117,7 @@ TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
   std::vector<double> max_acceleration = { 1, 1, 1, 1, 1, 1 };
   TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
   EXPECT_TRUE(time_parameterization.compute(*trajectory, max_velocity, max_acceleration));
-  ASSERT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 5.0);
+  ASSERT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 5.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineDynamicParams)
@@ -137,7 +137,7 @@ TEST(TestTimeParameterization, TestIterativeSplineDynamicParams)
   TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
   EXPECT_TRUE(time_parameterization.compute(
       *trajectory, max_velocity, max_acceleration, max_velocity_scaling_factors, max_acceleration_scaling_factors));
-  EXPECT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 5.0);
+  EXPECT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 5.0);
 
   program = createStraightTrajectory();
   max_velocity_scaling_factors[0] = 0.5;
@@ -155,7 +155,7 @@ TEST(TestTimeParameterization, TestRepeatedPoint)
   std::vector<double> max_acceleration = { 1, 1, 1, 1, 1, 1 };
   TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
   EXPECT_TRUE(time_parameterization.compute(*trajectory, max_velocity, max_acceleration));
-  ASSERT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 0.001);
+  ASSERT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 0.001);
 }
 
 int main(int argc, char** argv)

--- a/tesseract_time_parameterization/test/time_optimal_trajectory_generation_tests.cpp
+++ b/tesseract_time_parameterization/test/time_optimal_trajectory_generation_tests.cpp
@@ -346,7 +346,7 @@ void runTrajectoryContainerInterfaceTest(double path_tolerance)
   max_acceleration << 1, 1, 1, 1, 1, 1;
   TrajectoryContainer::Ptr trajectory = std::make_shared<InstructionsTrajectory>(program);
   EXPECT_TRUE(solver.computeTimeStamps(*trajectory, max_velocity, max_acceleration));
-  ASSERT_LT(program.back().cast_const<MoveInstruction>()->getWaypoint().cast_const<StateWaypoint>()->time, 5.0);
+  ASSERT_LT(program.back().as<MoveInstruction>().getWaypoint().as<StateWaypoint>().time, 5.0);
 }
 
 TEST(time_optimal_trajectory_generation, testTrajectoryContainerInterface)


### PR DESCRIPTION
The time parameterization was specific to taking a command language as input. We currently have a need to just take the results out of the sqp solver and run time parameterization. This introduces a TrajectoryContainer class which you can implement for different data structures which both of the current time parameterization implementations now support. 

Also updated time optimal implementation so it does not have to modify the results structure. @mpowelson In this case I left the computeTimeStamps which takes the CompositeInstruction until you have time to test the new implementation to avoid causing any issues if it does not perform as desired. 