### PR TITLE
Enable OMPL to plan for paths with more than one instruction

### DIFF
--- a/tesseract_motion_planners/test/ompl_planner_tests.cpp
+++ b/tesseract_motion_planners/test/ompl_planner_tests.cpp
@@ -187,12 +187,14 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
 
   // Define Plan Instructions
   PlanInstruction plan_f1(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE");
+  PlanInstruction plan_f2(wp1, PlanInstructionType::FREESPACE, "TEST_PROFILE");
 
   // Create a program
   CompositeInstruction program;
   program.setStartInstruction(start_instruction);
   program.setManipulatorInfo(manip);
   program.push_back(plan_f1);
+  program.push_back(plan_f2);
 
   // Create a seed
   CompositeInstruction seed = generateSeed(program, cur_state, env, 3.14, 1.0, 3.14, 10);
@@ -232,9 +234,14 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
 
   EXPECT_TRUE(&status);
   EXPECT_TRUE(planner_response.results.hasStartInstruction());
-  EXPECT_EQ(getMoveInstructionCount(planner_response.results), 11);
+  EXPECT_EQ(getMoveInstructionCount(planner_response.results), 21);  // 10 per segment + start a instruction
+  EXPECT_EQ(planner_response.results.size(), 2);
   EXPECT_TRUE(wp1.isApprox(getJointPosition(getFirstMoveInstruction(planner_response.results)->getWaypoint()), 1e-5));
-  EXPECT_TRUE(wp2.isApprox(getJointPosition(getLastMoveInstruction(planner_response.results)->getWaypoint()), 1e-5));
+  EXPECT_TRUE(wp2.isApprox(
+      getJointPosition(
+          getLastMoveInstruction(*(planner_response.results.front().cast<CompositeInstruction>()))->getWaypoint()),
+      1e-5));
+  EXPECT_TRUE(wp1.isApprox(getJointPosition(getLastMoveInstruction(planner_response.results)->getWaypoint()), 1e-5));
 
   // Check for start state in collision error
   std::vector<double> swp = { 0, 0.7, 0.0, 0, 0.0, 0, 0.0 };

--- a/tesseract_process_managers/examples/freespace_example_program.h
+++ b/tesseract_process_managers/examples/freespace_example_program.h
@@ -27,6 +27,10 @@ inline CompositeInstruction freespaceExampleProgramIIWA(const std::string& compo
   plan_f0.setDescription("freespace_motion");
   program.push_back(plan_f0);
 
+  Waypoint wp3 = JointWaypoint(joint_names, Eigen::VectorXd::Zero(7));
+  PlanInstruction plan_f1(wp3, PlanInstructionType::FREESPACE);
+  program.push_back(plan_f1);
+
   return program;
 }
 
@@ -46,6 +50,10 @@ inline CompositeInstruction freespaceExampleProgramABB(const std::string& compos
   PlanInstruction plan_f0(wp2, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f0.setDescription("freespace_motion");
   program.push_back(plan_f0);
+
+  Waypoint wp3 = JointWaypoint(joint_names, Eigen::VectorXd::Zero(6));
+  PlanInstruction plan_f1(wp3, PlanInstructionType::FREESPACE);
+  program.push_back(plan_f1);
 
   return program;
 }

--- a/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
+++ b/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
@@ -255,8 +255,8 @@ TEST_F(TesseractProcessManagerUnit, FreespaceSimpleMotionPlannerDefaultLVSPlanPr
   auto mcnt = getMoveInstructionCount(response.results);
 
   // The first plan instruction is the start instruction and every other plan instruction should be converted into
-  // ten move instruction.
-  EXPECT_EQ(19, mcnt);
+  // 32 move instruction.
+  EXPECT_EQ(65, mcnt);
   EXPECT_TRUE(response.results.hasStartInstruction());
   EXPECT_FALSE(response.results.getManipulatorInfo().empty());
 }

--- a/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
+++ b/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
@@ -256,7 +256,7 @@ TEST_F(TesseractProcessManagerUnit, FreespaceSimpleMotionPlannerDefaultLVSPlanPr
 
   // The first plan instruction is the start instruction and every other plan instruction should be converted into
   // 32 move instruction.
-  EXPECT_EQ(65, mcnt);
+  EXPECT_EQ(37, mcnt);
   EXPECT_TRUE(response.results.hasStartInstruction());
   EXPECT_FALSE(response.results.getManipulatorInfo().empty());
 }


### PR DESCRIPTION
This allows OMPL to process more than one plan instruction. Currently it just serially processes them on after another. They naively pass goal of the prior segment as the start of the next. This should work for joint via points, but we probably want to do something more sophisticated in the future for cartesian via points to guarantee that the same solution is used for adjacent segments.

Attached is the freespace manager example showing OMPL planning from a joint waypoint to a cartesian waypoint and back.

https://user-images.githubusercontent.com/12128406/112055658-bfe91200-8b1c-11eb-8c8d-4c3a0d202afa.mp4

