### PR TITLE
Reduce limits slightly in FixStateBoundsTaskGenerator

### DIFF
--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_bounds_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_bounds_task_generator.h
@@ -51,6 +51,12 @@ struct FixStateBoundsProfile
 
   /** @brief Maximum amount the process is allowed to correct. If deviation is further than this, it will fail */
   double max_deviation_global = std::numeric_limits<double>::max();
+
+  /** @brief Amount to reduce the upper bounds before clamping limits. Should be > 1 */
+  double upper_bounds_reduction{ std::numeric_limits<float>::epsilon() };
+
+  /** @brief Amount to increase the lower bounds before clamping limits. Should be > 1 */
+  double lower_bounds_reduction{ std::numeric_limits<float>::epsilon() };
 };
 using FixStateBoundsProfileMap = std::unordered_map<std::string, FixStateBoundsProfile::ConstPtr>;
 

--- a/tesseract_process_managers/src/task_generators/fix_state_bounds_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/fix_state_bounds_task_generator.cpp
@@ -85,6 +85,8 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
   }
 
   auto limits = fwd_kin->getLimits().joint_limits;
+  limits.col(0) = limits.col(0).array() + cur_composite_profile->lower_bounds_reduction;
+  limits.col(1) = limits.col(1).array() - cur_composite_profile->upper_bounds_reduction;
   switch (cur_composite_profile->mode)
   {
     case FixStateBoundsProfile::Settings::START_ONLY:


### PR DESCRIPTION
When planning with OMPL I ran into issues where a goal would be 1e-15 outside of the joint limits and it would fail. This should fix that (and for any other similarly sensitive Tasks).