### PR TITLE
Enforce limits on result trajectory for all motion planners.

### DIFF
--- a/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
+++ b/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
@@ -237,6 +237,10 @@ tesseract_common::StatusCode OMPLMotionPlanner::solve(const PlannerRequest& requ
     // Get the results
     tesseract_common::TrajArray trajectory = p->getTrajectory();
 
+    // Enforce limits
+    for (Eigen::Index i = 0; i < trajectory.rows(); i++)
+      tesseract_common::enforcePositionLimits(trajectory.row(i), p->manip_fwd_kin->getLimits().joint_limits);
+
     assert(checkStartState(p->simple_setup->getProblemDefinition(), trajectory.row(0), p->extractor));
     assert(checkGoalState(p->simple_setup->getProblemDefinition(), trajectory.bottomRows(1).transpose(), p->extractor));
 

--- a/tesseract_motion_planners/src/ompl/profile/ompl_default_plan_profile.cpp
+++ b/tesseract_motion_planners/src/ompl/profile/ompl_default_plan_profile.cpp
@@ -390,7 +390,18 @@ void OMPLDefaultPlanProfile::applyGoalStates(OMPLProblem& prob,
         for (unsigned j = 0; j < dof; ++j)
           goal_state[j] = solution[static_cast<Eigen::Index>(j)];
 
-        goal_states->addState(goal_state);
+        goal_state.enforceBounds(); // @todo figure out what is going on
+        if (goal_state.satisfiesBounds())
+        {
+          goal_states->addState(goal_state);
+        }
+        else
+        {
+          CONSOLE_BRIDGE_logError("In OMPLDefaultPlanProfile: Goal state has invalid bounds");
+          goal_state.print();
+          goal_state.enforceBounds();
+          goal_state.print();
+        }
       }
     }
 
@@ -402,7 +413,7 @@ void OMPLDefaultPlanProfile::applyGoalStates(OMPLProblem& prob,
             CONSOLE_BRIDGE_logError(("Solution: " + std::to_string(i) + "  Links: " + contact.link_names[0] + ", " +
                                      contact.link_names[1] + "  Distance: " + std::to_string(contact.distance))
                                         .c_str());
-      throw std::runtime_error("In OMPLPlannerFreespaceConfig: All goal states are in collision");
+      throw std::runtime_error("In OMPLDefaultPlanProfile: All goal states are in collision");
     }
     prob.simple_setup->setGoal(goal_states);
   }
@@ -424,7 +435,7 @@ void OMPLDefaultPlanProfile::applyGoalStates(OMPLProblem& prob,
     tesseract_collision::ContactResultMap contact_map;
     if (checkStateInCollision(prob, joint_waypoint, contact_map))
     {
-      CONSOLE_BRIDGE_logError("In OMPLPlannerFreespaceConfig: Goal state is in collision");
+      CONSOLE_BRIDGE_logError("In OMPLDefaultPlanProfile: Goal state is in collision");
       for (const auto& contact_vec : contact_map)
         for (const auto& contact : contact_vec.second)
           CONSOLE_BRIDGE_logError(("Links: " + contact.link_names[0] + ", " + contact.link_names[1] +
@@ -436,7 +447,18 @@ void OMPLDefaultPlanProfile::applyGoalStates(OMPLProblem& prob,
     for (unsigned i = 0; i < dof; ++i)
       goal_state[i] = joint_waypoint[i];
 
-    prob.simple_setup->setGoalState(goal_state);
+    goal_state.enforceBounds(); // @todo figure out what is going on
+    if (goal_state.satisfiesBounds())
+    {
+      prob.simple_setup->setGoalState(goal_state);
+    }
+    else
+    {
+      CONSOLE_BRIDGE_logError("In OMPLDefaultPlanProfile: Goal state has invalid bounds");
+      goal_state.print();
+      goal_state.enforceBounds();
+      goal_state.print();
+    }
   }
 }
 
@@ -479,12 +501,23 @@ void OMPLDefaultPlanProfile::applyStartStates(OMPLProblem& prob,
       // instead of the isValid function to avoid unnecessary collision checks.
       if (!checkStateInCollision(prob, solution, contact_map_vec[i]))
       {
-        found_start_state = true;
         ompl::base::ScopedState<> start_state(prob.simple_setup->getStateSpace());
         for (unsigned j = 0; j < dof; ++j)
           start_state[j] = solution[static_cast<Eigen::Index>(j)];
 
-        prob.simple_setup->addStartState(start_state);
+        start_state.enforceBounds(); // @todo figure out what is going on
+        if (start_state.satisfiesBounds())
+        {
+          found_start_state = true;
+          prob.simple_setup->addStartState(start_state);
+        }
+        else
+        {
+          CONSOLE_BRIDGE_logError("In OMPLDefaultPlanProfile: Start state has invalid bounds");
+          start_state.print();
+          start_state.enforceBounds();
+          start_state.print();
+        }
       }
     }
 
@@ -530,7 +563,18 @@ void OMPLDefaultPlanProfile::applyStartStates(OMPLProblem& prob,
     for (unsigned i = 0; i < dof; ++i)
       start_state[i] = joint_waypoint[i];
 
-    prob.simple_setup->addStartState(start_state);
+    start_state.enforceBounds(); // @todo figure out what is going on
+    if (start_state.satisfiesBounds())
+    {
+      prob.simple_setup->addStartState(start_state);
+    }
+    else
+    {
+      CONSOLE_BRIDGE_logError("In OMPLDefaultPlanProfile: Start state has invalid bounds");
+      start_state.print();
+      start_state.enforceBounds();
+      start_state.print();
+    }
   }
 }
 

--- a/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -164,6 +164,13 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(const PlannerRequest& r
   // Get the results
   tesseract_common::TrajArray trajectory = getTraj(opt.x(), problem->GetVars());
 
+  // Enforce limits
+  for (Eigen::Index i = 0; i < trajectory.rows(); i++)
+  {
+    assert(tesseract_common::satisfiesPositionLimits(trajectory.row(i), problem->GetKin()->getLimits().joint_limits));
+    tesseract_common::enforcePositionLimits(trajectory.row(i), problem->GetKin()->getLimits().joint_limits);
+  }
+
   // Flatten the results to make them easier to process
   response.results = request.seed;
   auto results_flattened = flattenProgramToPattern(response.results, request.instructions);

--- a/tesseract_motion_planners/src/trajopt_ifopt/trajopt_ifopt_motion_planner.cpp
+++ b/tesseract_motion_planners/src/trajopt_ifopt/trajopt_ifopt_motion_planner.cpp
@@ -155,6 +155,14 @@ tesseract_common::StatusCode TrajOptIfoptMotionPlanner::solve(const PlannerReque
                                             static_cast<Eigen::Index>(problem->vars.size()),
                                             static_cast<Eigen::Index>(problem->vars[0]->GetValues().size()));
 
+  // Enforce limits
+  for (Eigen::Index i = 0; i < trajectory.rows(); i++)
+  {
+    assert(
+        tesseract_common::satisfiesPositionLimits(trajectory.row(i), problem->manip_fwd_kin->getLimits().joint_limits));
+    tesseract_common::enforcePositionLimits(trajectory.row(i), problem->manip_fwd_kin->getLimits().joint_limits);
+  }
+
   // Flatten the results to make them easier to process
   response.results = request.seed;
   auto results_flattened = flattenProgramToPattern(response.results, request.instructions);

--- a/tesseract_motion_planners/test/simple_planner_fixed_size_interpolation.cpp
+++ b/tesseract_motion_planners/test/simple_planner_fixed_size_interpolation.cpp
@@ -118,6 +118,7 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeInterpolationUnit, JointCart_Joint
   request.env_state = env_->getCurrentState();
   JointWaypoint wp1(joint_names_, Eigen::VectorXd::Zero(7));
   CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
+  wp2.waypoint.translation() = Eigen::Vector3d(0.25, 0, 1);
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
@@ -143,6 +144,7 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeInterpolationUnit, CartJoint_Joint
   request.env = env_;
   request.env_state = env_->getCurrentState();
   CartesianWaypoint wp1 = Eigen::Isometry3d::Identity();
+  wp1.waypoint.translation() = Eigen::Vector3d(0.25, 0, 1);
   JointWaypoint wp2(joint_names_, Eigen::VectorXd::Zero(7));
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
@@ -166,7 +168,9 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeInterpolationUnit, CartCart_JointI
   request.env = env_;
   request.env_state = env_->getCurrentState();
   CartesianWaypoint wp1 = Eigen::Isometry3d::Identity();
+  wp1.waypoint.translation() = Eigen::Vector3d(0.25, -0.1, 1);
   CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
+  wp2.waypoint.translation() = Eigen::Vector3d(0.25, 0.1, 1);
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 

--- a/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
+++ b/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
@@ -193,7 +193,7 @@ TEST_F(TesseractProcessManagerUnit, RasterSimpleMotionPlannerDefaultLVSPlanProfi
 
   // The first plan instruction is the start instruction and every other plan instruction should be converted into
   // ten move instruction.
-  EXPECT_EQ(98, mcnt);
+  EXPECT_EQ(161, mcnt);
   EXPECT_TRUE(response.results.hasStartInstruction());
   EXPECT_FALSE(response.results.getManipulatorInfo().empty());
 }
@@ -256,7 +256,7 @@ TEST_F(TesseractProcessManagerUnit, FreespaceSimpleMotionPlannerDefaultLVSPlanPr
 
   // The first plan instruction is the start instruction and every other plan instruction should be converted into
   // ten move instruction.
-  EXPECT_EQ(33, mcnt);
+  EXPECT_EQ(19, mcnt);
   EXPECT_TRUE(response.results.hasStartInstruction());
   EXPECT_FALSE(response.results.getManipulatorInfo().empty());
 }


### PR DESCRIPTION
For some planners you are able to set the float type like Descartes. This can cause numerical issues with other planners because floats have a larger epsilon that doubles. For example if you generate a trajectory with Descartes using floats it is very possible to have ompl invalid start states because its function which checks bounds uses the epsilon for double. This PR adds a step for each planner which loops over the resulting trajectory and enforce limits to prevent this issue when chaining planners together. 

~~@mpowelson Hopefully this will eliminate the need to have tasks in the taskflow to fix bounds but this does not fix the other numerical issue with collisions.~~ See comment below.