### PR TITLE
Fix passing of meta information in simple planner and min_seed_length

### DIFF
--- a/tesseract_motion_planners/src/simple/profile/simple_planner_utils.cpp
+++ b/tesseract_motion_planners/src/simple/profile/simple_planner_utils.cpp
@@ -118,7 +118,7 @@ CompositeInstruction getInterpolatedComposite(const std::vector<std::string>& jo
     move_instruction.setManipulatorInfo(base_instruction.getManipulatorInfo());
     move_instruction.setDescription(base_instruction.getDescription());
     move_instruction.setProfile(base_instruction.getProfile());
-    composite.profile_overrides = base_instruction.profile_overrides;
+    move_instruction.profile_overrides = base_instruction.profile_overrides;
     composite.push_back(move_instruction);
   }
 

--- a/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -137,6 +137,7 @@ tesseract_common::StatusCode SimpleMotionPlanner::solve(const PlannerRequest& re
                                               MoveInstructionType::START,
                                               start_instruction.getProfile(),
                                               start_instruction.getManipulatorInfo());
+  move_start_instruction_seed.profile_overrides = start_instruction.profile_overrides;
   seed.setStartInstruction(move_start_instruction_seed);
 
   // Fill out the response
@@ -216,7 +217,8 @@ CompositeInstruction SimpleMotionPlanner::processCompositeInstruction(const Comp
                                                                       PlanInstruction& prev_instruction,
                                                                       const PlannerRequest& request) const
 {
-  CompositeInstruction seed(instructions.getProfile(), instructions.getOrder(), instructions.getManipulatorInfo());
+  CompositeInstruction seed(instructions);
+  seed.clear();
 
   for (const auto& instruction : instructions)
   {

--- a/tesseract_process_managers/src/task_generators/seed_min_length_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/seed_min_length_task_generator.cpp
@@ -80,9 +80,8 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   Instruction start_instruction = results.getStartInstruction();
   int subdivisions = static_cast<int>(std::ceil(static_cast<double>(min_length_) / static_cast<double>(cnt))) + 1;
 
-  CompositeInstruction new_results(results.getProfile(), results.getOrder(), results.getManipulatorInfo());
-  new_results.setDescription(results.getDescription());
-  new_results.setStartInstruction(results.getStartInstruction());
+  CompositeInstruction new_results(results);
+  new_results.clear();
 
   subdivide(new_results, results, start_instruction, subdivisions);
   results = new_results;
@@ -109,9 +108,8 @@ void SeedMinLengthTaskGenerator::subdivide(CompositeInstruction& composite,
     if (isCompositeInstruction(i))
     {
       const CompositeInstruction& cc = i.as<CompositeInstruction>();
-      CompositeInstruction new_cc(cc.getProfile(), cc.getOrder(), cc.getManipulatorInfo());
-      new_cc.setDescription(cc.getDescription());
-      new_cc.setStartInstruction(cc.getStartInstruction());
+      CompositeInstruction new_cc(cc);
+      new_cc.clear();
 
       subdivide(new_cc, cc, start_instruction, subdivisions);
       composite.push_back(new_cc);
@@ -133,10 +131,8 @@ void SeedMinLengthTaskGenerator::subdivide(CompositeInstruction& composite,
       // Convert to MoveInstructions
       for (long i = 1; i < states.cols(); ++i)
       {
-        MoveInstruction move_instruction(StateWaypoint(swp1.joint_names, states.col(i)), mi1.getMoveType());
-        move_instruction.setManipulatorInfo(mi1.getManipulatorInfo());
-        move_instruction.setDescription(mi1.getDescription());
-        move_instruction.setProfile(mi1.getProfile());
+        MoveInstruction move_instruction(mi1);
+        move_instruction.getWaypoint().as<StateWaypoint>().position = states.col(i);
         composite.push_back(move_instruction);
       }
 


### PR DESCRIPTION
I thought I already fixed this, but on master meta information gets lost in the simple planner and the min seed length task. This fixes it. 