### PR TITLE
Remove unused class_loader includes

### DIFF
--- a/tesseract_motion_planners/examples/chain_example.cpp
+++ b/tesseract_motion_planners/examples/chain_example.cpp
@@ -27,7 +27,6 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 #include <descartes_samplers/evaluators/euclidean_distance_edge_evaluator.h>
-#include <class_loader/class_loader.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/types.h>

--- a/tesseract_motion_planners/examples/freespace_example.cpp
+++ b/tesseract_motion_planners/examples/freespace_example.cpp
@@ -27,7 +27,6 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 #include <opw_kinematics/opw_parameters.h>
-#include <class_loader/class_loader.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/types.h>

--- a/tesseract_motion_planners/examples/raster_example.cpp
+++ b/tesseract_motion_planners/examples/raster_example.cpp
@@ -27,7 +27,6 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 #include <descartes_samplers/evaluators/euclidean_distance_edge_evaluator.h>
-#include <class_loader/class_loader.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/types.h>


### PR DESCRIPTION
I'm guessing this is some residual fallout from https://github.com/ros-industrial-consortium/tesseract/pull/577