### PR TITLE
Set taskflows default post collision check to leverage discrete lvs

### DIFF
--- a/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
+++ b/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
@@ -68,8 +68,6 @@ public:
   DescartesVertexEvaluatorAllocatorFn<FloatType> vertex_evaluator{ nullptr };
 #endif
 
-  double timing_constraint = std::numeric_limits<FloatType>::max();
-
   // Applied to sampled states
   bool enable_collision{ true };
   tesseract_collision::CollisionCheckConfig vertex_collision_check_config{ 0 };

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/cartesian_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/cartesian_taskflow.h
@@ -41,8 +41,8 @@ namespace tesseract_planning
 {
 struct CartesianTaskflowParams
 {
-  bool enable_post_contact_discrete_check{ false };
-  bool enable_post_contact_continuous_check{ true };
+  bool enable_post_contact_discrete_check{ true };
+  bool enable_post_contact_continuous_check{ false };
   bool enable_time_parameterization{ true };
 };
 

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/descartes_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/descartes_taskflow.h
@@ -41,8 +41,8 @@ namespace tesseract_planning
 {
 struct DescartesTaskflowParams
 {
-  bool enable_post_contact_discrete_check{ false };
-  bool enable_post_contact_continuous_check{ true };
+  bool enable_post_contact_discrete_check{ true };
+  bool enable_post_contact_continuous_check{ false };
   bool enable_time_parameterization{ true };
 };
 

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/freespace_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/freespace_taskflow.h
@@ -48,8 +48,8 @@ enum class FreespaceTaskflowType : int
 struct FreespaceTaskflowParams
 {
   FreespaceTaskflowType type{ FreespaceTaskflowType::DEFAULT };
-  bool enable_post_contact_discrete_check{ false };
-  bool enable_post_contact_continuous_check{ true };
+  bool enable_post_contact_discrete_check{ true };
+  bool enable_post_contact_continuous_check{ false };
   bool enable_time_parameterization{ true };
 };
 

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/ompl_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/ompl_taskflow.h
@@ -40,8 +40,8 @@ namespace tesseract_planning
 {
 struct OMPLTaskflowParams
 {
-  bool enable_post_contact_discrete_check{ false };
-  bool enable_post_contact_continuous_check{ true };
+  bool enable_post_contact_discrete_check{ true };
+  bool enable_post_contact_continuous_check{ false };
   bool enable_time_parameterization{ true };
 };
 

--- a/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/trajopt_taskflow.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/taskflow_generators/trajopt_taskflow.h
@@ -41,8 +41,8 @@ namespace tesseract_planning
 {
 struct TrajOptTaskflowParams
 {
-  bool enable_post_contact_discrete_check{ false };
-  bool enable_post_contact_continuous_check{ true };
+  bool enable_post_contact_discrete_check{ true };
+  bool enable_post_contact_continuous_check{ false };
   bool enable_time_parameterization{ true };
 };
 


### PR DESCRIPTION
The continuous collision post check is problematic when you have two links that can collide which are in close proximity to each where the beginning of a casted objects collides with the end of another casted collision object.

It also removed unused parameter in Descartes default plan profile.
