### PR TITLE
Update to latest edge evaluator API

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -13,7 +13,7 @@
 - git:
     local-name: descartes_light
     uri: https://github.com/swri-robotics/descartes_light.git
-    version: b56f39a53d88163778b3adc3597da2bba8eb120a
+    version: 539a25174b7e0f031babd04a4b2e6ccc310d1525
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git

--- a/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
+++ b/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
@@ -50,8 +50,8 @@ public:
                                   bool allow_collision = false,
                                   bool debug = false);
 
-  std::pair<bool, FloatType> evaluate(const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& start,
-                                      const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& end) const override;
+  std::pair<bool, FloatType> evaluate(const Eigen::Ref<const descartes_light::State<FloatType>>& start,
+                                      const Eigen::Ref<const descartes_light::State<FloatType>>& end) const override;
 
 protected:
   /** @brief The tesseract state solver */

--- a/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
+++ b/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
@@ -70,8 +70,8 @@ DescartesCollisionEdgeEvaluator<FloatType>::DescartesCollisionEdgeEvaluator(
 
 template <typename FloatType>
 std::pair<bool, FloatType>
-DescartesCollisionEdgeEvaluator<FloatType>::evaluate(const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& start,
-                                                     const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& end) const
+DescartesCollisionEdgeEvaluator<FloatType>::evaluate(const Eigen::Ref<const descartes_light::State<FloatType>>& start,
+                                                     const Eigen::Ref<const descartes_light::State<FloatType>>& end) const
 {
   assert(start.rows() == end.rows());
 


### PR DESCRIPTION
Ran into this when building everything on master. Updates to the latest Descartes API as changed in https://github.com/swri-robotics/descartes_light/pull/59